### PR TITLE
feat(ci): add automatic semantic versioning via conventional commits

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,32 @@
+name: auto-tag
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          default_bump: false
+          initial_version: "0.1.0"
+          tag_prefix: "v"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,14 +68,17 @@ gofmt -l .
 
 ## Release
 
-Tag and push to trigger GitHub Actions release workflow:
+Releases are fully automated via conventional commits:
 
-```bash
-git tag v0.1.0
-git push --tags
-```
+1. Merge to `main` triggers `auto-tag.yml`
+2. Conventional commit prefixes determine the version bump:
+   - `fix(scope):` → patch (0.0.x)
+   - `feat(scope):` → minor (0.x.0)
+   - `BREAKING CHANGE:` or `feat!:` → major (x.0.0)
+   - `docs:`, `ci:`, `chore:`, `refactor:`, `test:` → no tag, no release
+3. The created tag triggers `release.yml` → GoReleaser builds linux/darwin binaries (amd64/arm64), publishes a GitHub Release, and publishes npm packages
 
-GoReleaser builds linux/darwin binaries (amd64/arm64) and publishes a GitHub Release.
+The auto-tag workflow uses a GitHub App token (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) to push tags that trigger downstream workflows.
 
 ## MCP Development Setup
 


### PR DESCRIPTION
## Summary
- Add `auto-tag.yml` workflow that analyzes conventional commits on push to main and creates semver tags automatically
- Uses GitHub App token (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) so tags trigger the existing `release.yml` (GoReleaser + npm publish)
- `default_bump: false` — only `feat`, `fix`, and `BREAKING CHANGE` create tags; `docs`, `ci`, `chore` etc. are skipped
- First tag will be `v0.1.0` (configured via `initial_version`)
- Update CLAUDE.md release section to document the new automated flow

## Test plan
- [ ] Merge this PR to main
- [ ] Verify `auto-tag` workflow runs: `gh run list -w auto-tag`
- [ ] Verify tag `v0.1.0` is created: `gh api repos/Nosmoht/talos-mcp-server/tags --jq '.[].name'`
- [ ] Verify `release.yml` triggers and GoReleaser publishes a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)