### PR TITLE
feat(transport): add Streamable HTTP transport mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,11 @@ Prompts are guided workflows that instruct the AI agent which tools to call and 
 
 ## Logging
 
-Mutating tools (`talos_service_action`, `talos_reboot`, `talos_upgrade`, `talos_patch_config`) emit `notifications/message` audit events to connected MCP clients:
+Mutating tools (`talos_service_action`, `talos_reboot`, `talos_upgrade`, `talos_patch_config`) emit `notifications/message` audit events to connected MCP clients in **stdio mode**:
 - `info` level: tool invocation with tool name, target nodes, and arguments summary
 - `error` level: operational errors (after guard checks pass, on Talos gRPC failures)
 
-Delivery is best-effort — clients must call `logging/setLevel` to receive notifications. Server-side `log.Printf` audit lines are always written regardless of MCP client state.
+Delivery is best-effort — clients must call `logging/setLevel` to receive notifications. In **HTTP mode**, audit lines are written to server stderr only (MCP notifications not emitted).
 
 ## HTTP Transport
 
@@ -98,6 +98,8 @@ openssl rand -hex 32
 ```
 
 **TLS** — not terminated by the binary; use a reverse proxy (nginx, Caddy, Tailscale funnel). The reverse proxy must preserve the `Origin` request header.
+
+`DisableLocalhostProtection` is enabled — the built-in DNS rebinding guard is inactive. The server must be behind a reverse proxy or on a trusted network. The reverse proxy must preserve the `Origin` request header — the SDK's cross-origin protection uses it to reject untrusted origins; stripping it will cause all MCP client connections to fail.
 
 **MCP log notifications** (`notifications/message`) are only emitted in stdio mode. In HTTP mode, audit lines are written to the server's stderr only.
 

--- a/cmd/talos-mcp/main.go
+++ b/cmd/talos-mcp/main.go
@@ -272,7 +272,9 @@ func runServer(ctx context.Context, server *mcp.Server, addr, token string) erro
 	// Shutdown on context cancellation.
 	go func() { //nolint:gosec // G118: intentional — shutdown uses a fresh background context, not the cancelled one
 		<-ctx.Done()
-		_ = httpSrv.Shutdown(context.Background()) //nolint:contextcheck
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second) //nolint:contextcheck
+		defer cancel()
+		_ = httpSrv.Shutdown(shutdownCtx)
 	}()
 
 	log.Printf("HTTP transport listening on %s", addr) //nolint:gosec // G706: addr is operator-supplied config, not user input

--- a/cmd/talos-mcp/main_test.go
+++ b/cmd/talos-mcp/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -53,11 +54,17 @@ func TestBuildTokenVerifier(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for wrong token")
 	}
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Errorf("expected auth.ErrInvalidToken for wrong token, got %v", err)
+	}
 
 	// empty token
 	_, err = verifier(context.Background(), "", nil)
 	if err == nil {
 		t.Error("expected error for empty token")
+	}
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Errorf("expected auth.ErrInvalidToken for empty token, got %v", err)
 	}
 }
 

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -22,12 +22,13 @@ import (
 // Handlers holds the Talos client and exposes MCP tool handler methods.
 type Handlers struct {
 	Client *talos.Client
+	// logger is the active slog.Logger for MCP log notifications.
+	// It is swapped atomically per session in stdio mode.
 	logger atomic.Pointer[slog.Logger]
 }
 
-// SetLogger installs the MCP-backed slog.Logger for this session.
-// Note: uses last-writer-wins semantics — intentional for single-session
-// stdio transport. Not safe for concurrent multi-client deployments.
+// SetLogger replaces the active logger used for MCP log notifications.
+// In stdio mode this is called once per session from InitializedHandler.
 func (h *Handlers) SetLogger(l *slog.Logger) {
 	h.logger.Store(l)
 }


### PR DESCRIPTION
## Summary

- Adds opt-in Streamable HTTP transport alongside existing stdio mode (default unchanged)
- `TALOS_MCP_HTTP_ADDR` (e.g. `:8080`) enables HTTP mode; unset → stdio
- `TALOS_MCP_AUTH_TOKEN` required in HTTP mode — server refuses to start without it; validated before any defers are registered
- Bearer token middleware via `auth.RequireBearerToken` with `crypto/subtle.ConstantTimeCompare` (timing-safe)
- `InitializedHandler` / MCP log notifications only active in stdio mode — HTTP mode avoids last-writer-wins race on shared `Handlers.logger` across concurrent sessions
- Graceful shutdown via `context.WithTimeout(30s)` on ctx cancellation
- `DisableLocalhostProtection: true` documented — server must be behind a reverse proxy or trusted network
- `TALOS_MCP_READ_ONLY` added to CLAUDE.md env var table (was missing)

## Test plan

- [ ] `make check` passes (fmt + vet + lint + test with race detector)
- [ ] `TestValidateHTTPConfig` — stdio/no-addr, HTTP+token, HTTP+no-token
- [ ] `TestBuildTokenVerifier` — correct token, wrong token (`auth.ErrInvalidToken`), empty token, non-zero future expiration
- [ ] `TestHTTPHandler_Integration` — 401 without bearer, non-401 with valid bearer (httptest.NewServer, no live Talos)
- [ ] Manual: `TALOS_MCP_HTTP_ADDR=:8080 TALOS_MCP_AUTH_TOKEN=$(openssl rand -hex 32) ./talos-mcp` → verify HTTP server starts and requires auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)