### PR TITLE
fix(hooks): resolve review path in worktrees and strip type: prefix in YAML parser

### DIFF
--- a/.claude/hooks/pre-commit
+++ b/.claude/hooks/pre-commit
@@ -12,7 +12,16 @@
 
 set -uo pipefail
 
-REVIEW_BASE=".claude/reviews"
+# Resolve main repo root — works from both main repo and git worktrees.
+# git rev-parse --git-common-dir returns ".git" (relative) in the main worktree
+# and an absolute path in linked worktrees.
+_GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null || echo ".git")
+if [[ "$_GIT_COMMON" = /* ]]; then
+  _MAIN_REPO=$(cd "$_GIT_COMMON/.." && pwd)
+else
+  _MAIN_REPO=$(pwd)
+fi
+REVIEW_BASE="$_MAIN_REPO/.claude/reviews"
 
 error() {
   echo "COMMIT BLOCKED: $1" >&2
@@ -76,6 +85,8 @@ if inline:
     if raw:
         for item in raw.split(','):
             item = item.strip().strip('"\'')
+            # Strip leading 'type:' prefix (LLM sometimes writes '- type: value')
+            item = re.sub(r'^type:\s*', '', item)
             if item:
                 print(item)
     sys.exit(0)
@@ -85,7 +96,11 @@ if ml:
     for line in ml.group(1).splitlines():
         m = re.match(r'[ \t]+-[ \t]+(\S.*)', line)
         if m:
-            print(m.group(1).strip().strip('"\''))
+            item = m.group(1).strip().strip('"\'')
+            # Strip leading 'type:' prefix (LLM sometimes writes '- type: value')
+            item = re.sub(r'^type:\s*', '', item)
+            if item:
+                print(item)
 PYEOF
 }
 

--- a/.claude/hooks/require-review.sh
+++ b/.claude/hooks/require-review.sh
@@ -69,7 +69,16 @@ fi
 
 # ── Commit detected: validate review artifacts ──────────────────────────────
 
-REVIEW_BASE=".claude/reviews"
+# Resolve main repo root — works from both main repo and git worktrees.
+# git rev-parse --git-common-dir returns ".git" (relative) in the main worktree
+# and an absolute path in linked worktrees.
+_GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null || echo ".git")
+if [[ "$_GIT_COMMON" = /* ]]; then
+  _MAIN_REPO=$(cd "$_GIT_COMMON/.." && pwd)
+else
+  _MAIN_REPO=$(pwd)
+fi
+REVIEW_BASE="$_MAIN_REPO/.claude/reviews"
 
 if [ ! -d "$REVIEW_BASE" ]; then
   deny "BLOCKED: No .claude/reviews/ directory found. Create review artifacts before committing. See CLAUDE.md governance section."
@@ -132,6 +141,8 @@ if inline:
     if raw:
         for item in raw.split(','):
             item = item.strip().strip('"\'')
+            # Strip leading 'type:' prefix (LLM sometimes writes '- type: value')
+            item = re.sub(r'^type:\s*', '', item)
             if item:
                 print(item)
     sys.exit(0)
@@ -145,7 +156,11 @@ if ml:
     for line in ml.group(1).splitlines():
         m = re.match(r'[ \t]+-[ \t]+(\S.*)', line)
         if m:
-            print(m.group(1).strip().strip('"\''))
+            item = m.group(1).strip().strip('"\'')
+            # Strip leading 'type:' prefix (LLM sometimes writes '- type: value')
+            item = re.sub(r'^type:\s*', '', item)
+            if item:
+                print(item)
 PYEOF
 }
 


### PR DESCRIPTION
## What does this PR do?

Two recurring bugs in the review enforcement hooks are fixed:

**Bug 1 — `.claude/reviews/` not found when committing from a worktree**

Both `require-review.sh` and `pre-commit` used `REVIEW_BASE=".claude/reviews"` as a relative path. When running inside a git worktree (CWD = `.claude/worktrees/<slug>/`), this path doesn't exist — the reviews live in the main repo. Fixed by using `git rev-parse --git-common-dir` to resolve the main repo root at runtime, which returns `.git` (relative) in the main worktree and an absolute path in linked worktrees.

**Bug 2 — Escalation artifact named `review-type: operational-safety.md`**

The `get_yaml_list` YAML parser captured `type: operational-safety` when the LLM-generated review.md wrote `- type: operational-safety` (object notation) instead of `- operational-safety` (plain string). Fixed by stripping a leading `type:` prefix from parsed list items in both the inline and multiline code paths. The strip is fail-closed: if the prefix removal yields an empty string, the item is discarded, causing a deny.

## Checklist

- [x] `make check` passes locally (fmt + vet + lint + test)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] New/changed tools include tests — N/A (shell scripts, not Go)
- [ ] Documentation updated if applicable — N/A (hook internals only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)