### PR TITLE
chore(claude): add loop-agent permissions and fix worktree base

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,28 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "Agent",
+      "mcp__github__get_me",
+      "mcp__github__list_issues",
+      "mcp__github__search_issues",
+      "mcp__github__search_pull_requests",
+      "mcp__github__list_pull_requests",
+      "mcp__github__list_branches",
+      "mcp__github__pull_request_read",
+      "mcp__github__issue_read",
+      "mcp__github__create_pull_request",
+      "mcp__github__create_branch",
+      "mcp__github__issue_write",
+      "mcp__github__add_issue_comment",
+      "mcp__github__update_pull_request"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,8 +143,9 @@ Every code change (features, fixes, refactors) is developed in an isolated git w
 
 ```bash
 # Create a new worktree for a feature or fix (slug = change-id)
-git worktree add -b feat/<slug> .claude/worktrees/<slug> main
-# or: git worktree add -b fix/<slug> .claude/worktrees/<slug> main
+git fetch origin main
+git worktree add -b feat/<slug> .claude/worktrees/<slug> origin/main
+# or: git worktree add -b fix/<slug> .claude/worktrees/<slug> origin/main
 ```
 
 Work inside `.claude/worktrees/<slug>/` for the full lifecycle of the change.
@@ -175,12 +176,13 @@ git branch -d feat/<slug>
 
 ### Workflow summary
 
-1. Create worktree: `git worktree add -b feat/<slug> .claude/worktrees/<slug> main`
-2. Work in `.claude/worktrees/<slug>/`
-3. Run reviews (see Change Governance below)
-4. Rebase: `git fetch origin main && git rebase origin/main`
-5. Push branch and open PR
-6. After merge: remove worktree and delete local branch
+1. Fetch latest: `git fetch origin main`
+2. Create worktree: `git worktree add -b feat/<slug> .claude/worktrees/<slug> origin/main`
+3. Work in `.claude/worktrees/<slug>/`
+4. Run reviews (see Change Governance below)
+5. Rebase: `git fetch origin main && git rebase origin/main`
+6. Push branch and open PR
+7. After merge: remove worktree and delete local branch
 
 ## Release
 


### PR DESCRIPTION
## Summary

- **`settings.json`**: adds `permissions.allow` so unattended loop agents (Claude Code `/loop` cron runs) can operate without blocking on interactive permission prompts. Covers standard file/shell tools and a targeted set of read+write GitHub MCP tools. Mutating Talos tools and GitHub file-push tools remain gated by the existing `require-review.sh` hook.
- **`CLAUDE.md`**: fixes worktree setup to branch from `origin/main` after an explicit `git fetch`, instead of local `main`. Ensures every agent run (loop or manual) starts from the latest remote state, not a potentially stale local ref.

## Why

Team members using `/loop` to tackle GitHub issues autonomously need these permissions pre-granted — unattended runs can't wait for interactive approval. Without the `origin/main` fix, loop runs on stale local branches would produce PRs based on outdated code.

## Test plan

- [ ] Verify `settings.json` is valid JSON (`jq . .claude/settings.json`)
- [ ] Verify a `/loop` run starts without permission prompts for listed tools
- [ ] Verify `require-review.sh` still fires on `git commit` (hook gating intact)
- [ ] Verify new worktrees branch from `origin/main` (not local `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)