### PR TITLE
ci: validate .claude/settings.json syntax on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,18 @@ jobs:
           go-version-file: go.mod
       - run: go build -o talos-mcp ./cmd/talos-mcp
 
+  validate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - name: Validate .claude/settings.json
+        run: jq empty .claude/settings.json
+
   # Single required status check: passes when all CI jobs pass or are legitimately skipped.
   # Skipped = no Go-relevant files changed on this PR.
   merge-guard:
     if: always() && !cancelled()
-    needs: [lint, test, build, verify]
+    needs: [lint, test, build, verify, validate-config]
     runs-on: ubuntu-latest
     steps:
       - name: Fail on CI failure or cancellation


### PR DESCRIPTION
## Summary

- Adds a `validate-config` job to `ci.yml` that runs `jq empty .claude/settings.json` on every push and PR
- Wires `validate-config` into `merge-guard` so a malformed settings file blocks merge

## Why

`.claude/settings.json` enforces loop-agent permissions and review hooks for the whole team. A JSON syntax error silently disables all settings — catching it in CI prevents broken governance from landing on main.

The job has no path filter by design: the file should be valid on every PR, not only when it was directly modified.

## Test plan

- [ ] CI passes on this PR (`validate-config` job green)
- [ ] Temporarily corrupt `.claude/settings.json` on a test branch → `validate-config` fails and `merge-guard` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)