### PR TITLE
fix(deps): bump Go to 1.26.2 to resolve stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Nosmoht/talos-mcp-server
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/cosi-project/runtime v1.14.1


### PR DESCRIPTION
## Summary

Bumps `go 1.26.1` → `go 1.26.2` in `go.mod` to fix 5 stdlib vulnerabilities reported by `govulncheck`:

| ID | Package | Description |
|---|---|---|
| GO-2026-4947 | `crypto/x509` | Unexpected work during chain building |
| GO-2026-4946 | `crypto/x509` | Inefficient policy validation |
| GO-2026-4870 | `crypto/tls` | Unauthenticated TLS 1.3 KeyUpdate DoS |
| GO-2026-4866 | `crypto/x509` | Case-sensitive name constraints auth bypass |
| GO-2026-4865 | `html/template` | XSS (JsBraceDepth context tracking) |

`go.sum` is unchanged — all affected packages are stdlib (shipped with the toolchain, not tracked as module dependencies). CI uses `go-version-file: go.mod` so the runner picks up 1.26.2 automatically.

## Test plan

- [x] `verify` job passes (`govulncheck` reports no vulnerabilities)
- [x] `test`, `build`, `lint` jobs pass (patch release, no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)