### PR TITLE
feat(safety): add optional blocklist for critical config paths in talos_patch_config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Environment variables (set in `.mcp.json` env block or shell):
 | `TALOS_MCP_AUTH_TOKEN` | (unset) | Required bearer token when HTTP mode is active |
 | `TALOS_MCP_ALLOWED_NODES` | (unset) | Comma-separated IPs, hostnames, and CIDR ranges permitted as tool targets. Unset or empty allows all nodes. |
 | `TALOS_MCP_ALLOWED_PATHS` | (all) | Comma-separated path prefixes permitted for `talos_read_file` and `talos_list_files` (e.g. `/etc,/proc`). Unset or empty allows all paths. |
+| `TALOS_MCP_BLOCKED_CONFIG_PATHS` | (unset) | Comma-separated dot-path prefixes that `talos_patch_config` refuses to modify (e.g. `machine.security,cluster.etcd`). Blocks exact matches, child paths, and parent paths. Unset or empty disables the blocklist. |
 | `TALOS_MCP_SKIP_VERSION_CHECK` | `false` | Set to `"true"` to bypass upgrade path validation |
 | `TALOS_MCP_RATE_LIMIT` | `10` | HTTP mode: token-bucket refill rate (requests/second, float) |
 | `TALOS_MCP_RATE_BURST` | `20` | HTTP mode: token-bucket burst capacity (int) |

--- a/cmd/talos-mcp/main.go
+++ b/cmd/talos-mcp/main.go
@@ -16,6 +16,9 @@
 //     call targeting a node not in this list is rejected. Unset or empty allows all nodes.
 //   - TALOS_MCP_ALLOWED_PATHS: comma-separated path prefixes allowed for talos_read_file
 //     and talos_list_files (e.g. "/etc,/proc"). Unset or empty allows all paths.
+//   - TALOS_MCP_BLOCKED_CONFIG_PATHS: comma-separated dot-path prefixes that
+//     talos_patch_config refuses to modify (e.g. "machine.security,cluster.etcd").
+//     Unset or empty disables the blocklist (all paths allowed).
 //   - TALOS_MCP_SKIP_VERSION_CHECK: set to "true" to bypass upgrade path validation
 //   - TALOS_MCP_RATE_LIMIT: HTTP mode requests/second (float, default 10)
 //   - TALOS_MCP_RATE_BURST: HTTP mode burst capacity (int, default 20)
@@ -33,6 +36,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -72,6 +76,7 @@ func main() {
 
 	allowedPaths := tools.ParseAllowedPaths(os.Getenv("TALOS_MCP_ALLOWED_PATHS"))
 	skipVersionCheck := os.Getenv("TALOS_MCP_SKIP_VERSION_CHECK") == "true"
+	blockedConfigPaths := splitNonEmpty(os.Getenv("TALOS_MCP_BLOCKED_CONFIG_PATHS"), ",")
 
 	if err := validateHTTPConfig(httpAddr, authToken); err != nil {
 		stop()
@@ -118,11 +123,18 @@ func main() {
 		slog.Warn("version check disabled (TALOS_MCP_SKIP_VERSION_CHECK=true)")
 	}
 
+	if len(blockedConfigPaths) > 0 {
+		slog.Info("config path blocklist active", "entries", len(blockedConfigPaths)) //nolint:gosec // G706: entry count is an integer, not user-controlled string input
+	} else {
+		slog.Info("config path blocklist disabled")
+	}
+
 	h := &tools.Handlers{
-		Client:           tc,
-		AllowedNodes:     allowedNodes,
-		AllowedPaths:     allowedPaths,
-		SkipVersionCheck: skipVersionCheck,
+		Client:             tc,
+		AllowedNodes:       allowedNodes,
+		AllowedPaths:       allowedPaths,
+		SkipVersionCheck:   skipVersionCheck,
+		BlockedConfigPaths: blockedConfigPaths,
 	}
 
 	serverOpts := &mcp.ServerOptions{
@@ -454,4 +466,19 @@ func runServer(ctx context.Context, server *mcp.Server, addr, token string, hc h
 		return fmt.Errorf("HTTP server: %w", err)
 	}
 	return nil
+}
+
+// splitNonEmpty splits s by sep and returns non-empty, trimmed tokens.
+// Returns nil when s is empty.
+func splitNonEmpty(s, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(s, sep) {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -22,6 +22,10 @@ type Handlers struct {
 	AllowedNodes     *talos.NodeAllowlist
 	AllowedPaths     []string // set once at startup; read-only afterward
 	SkipVersionCheck bool     // set once at startup; read-only afterward
+	// BlockedConfigPaths is the list of dot-separated config path prefixes that
+	// talos_patch_config refuses to modify. Empty means no restriction.
+	// Set once at startup; read-only afterward.
+	BlockedConfigPaths []string
 	// patchMu serialises concurrent HandlePatchConfig calls on a per-node basis.
 	// In HTTP multi-session mode two agents could otherwise both fetch the current
 	// config, each merge their own patch, and the second apply would silently

--- a/internal/tools/lifecycle.go
+++ b/internal/tools/lifecycle.go
@@ -500,6 +500,12 @@ func (h *Handlers) HandlePatchConfig(ctx context.Context, req *mcp.CallToolReque
 		return nil, nil, fmt.Errorf("patch_config refused: confirm must be explicitly set to true when dry_run is false")
 	}
 
+	// Blocklist guard: reject patches that touch operator-restricted config paths.
+	// Applied before the network round-trip so misuse is caught cheaply.
+	if err := checkBlockedPaths([]byte(args.Patch), h.BlockedConfigPaths); err != nil {
+		return nil, nil, err
+	}
+
 	ctx, err := talos.WithNodes(ctx, args.Nodes, h.AllowedNodes)
 	if err != nil {
 		return nil, nil, err
@@ -668,6 +674,14 @@ func (h *Handlers) HandleApplyConfig(ctx context.Context, req *mcp.CallToolReque
 		Confirm:    args.Confirm,
 		Nodes:      args.Nodes,
 	}, args.Nodes)
+
+	// Blocklist guard: talos_apply_config replaces the entire machine config document,
+	// so it cannot be safely allowed when a path blocklist is active — any blocked path
+	// would be silently overwritten. Direct the caller to talos_patch_config instead,
+	// which supports targeted modifications that the blocklist can inspect.
+	if len(h.BlockedConfigPaths) > 0 {
+		return nil, nil, fmt.Errorf("talos_apply_config is disabled while TALOS_MCP_BLOCKED_CONFIG_PATHS is set: use talos_patch_config for targeted changes that respect the blocklist")
+	}
 
 	// Require exactly one node: each node has a unique machine config.
 	// Applying the same full config to multiple nodes risks overwriting node-specific settings

--- a/internal/tools/patch_blocklist.go
+++ b/internal/tools/patch_blocklist.go
@@ -1,0 +1,123 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// checkBlockedPaths returns an error when the patch touches any path listed in
+// blocked. It handles both RFC 6902 JSON Patch arrays and strategic merge
+// patches (YAML or JSON maps). An empty blocked slice is a no-op.
+func checkBlockedPaths(patchDoc []byte, blocked []string) error {
+	if len(blocked) == 0 {
+		return nil
+	}
+
+	paths, err := extractPatchPaths(patchDoc)
+	if err != nil {
+		return fmt.Errorf("inspect patch paths: %w", err)
+	}
+
+	for _, p := range paths {
+		// An empty path is an RFC 6902 root-document pointer ("/").
+		// A root replacement would overwrite every config key, including all
+		// blocked paths, so reject it whenever any blocklist is active.
+		if p == "" {
+			return fmt.Errorf("patch contains a root-document operation (RFC 6902 path \"/\") which would overwrite all blocked paths")
+		}
+
+		for _, b := range blocked {
+			if pathConflicts(p, b) {
+				return fmt.Errorf("patch targets blocked config path %q (blocked: %q)", p, b)
+			}
+		}
+	}
+
+	return nil
+}
+
+// pathConflicts reports whether patch path p conflicts with blocked path b.
+// Conflict means p equals b, p is a descendant of b, or p is an ancestor of b.
+func pathConflicts(p, b string) bool {
+	return p == b ||
+		strings.HasPrefix(p, b+".") ||
+		strings.HasPrefix(b, p+".")
+}
+
+// extractPatchPaths returns all dot-separated field paths touched by a patch
+// document. Supports RFC 6902 JSON Patch arrays (extracts the "path" field of
+// each operation, normalised to dot notation) and strategic merge patches
+// (YAML or JSON maps, flattened to dot-paths).
+func extractPatchPaths(patchDoc []byte) ([]string, error) {
+	// Try RFC 6902: JSON array of operation objects.
+	var ops []struct {
+		Op   string `json:"op"`
+		Path string `json:"path"`
+		From string `json:"from"` // present for "move" and "copy" ops (RFC 6902 §4.3, §4.4)
+	}
+	if json.Unmarshal(patchDoc, &ops) == nil && len(ops) > 0 {
+		out := make([]string, 0, len(ops)*2)
+		for _, op := range ops {
+			out = append(out, normaliseJSONPointer(op.Path))
+			// "move" and "copy" also read from the "from" path; check it too so that
+			// an operation like {"op":"move","from":"/machine/security","path":"/x"}
+			// does not silently bypass the blocklist.
+			if (op.Op == "move" || op.Op == "copy") && op.From != "" {
+				out = append(out, normaliseJSONPointer(op.From))
+			}
+		}
+		return out, nil
+	}
+
+	// Strategic merge patch: YAML or JSON map.
+	var m map[string]any
+	if err := yaml.Unmarshal(patchDoc, &m); err != nil {
+		return nil, fmt.Errorf("parse patch as YAML/JSON: %w", err)
+	}
+
+	var paths []string
+	collectPaths("", m, &paths)
+
+	return paths, nil
+}
+
+// normaliseJSONPointer converts an RFC 6902 JSON pointer (e.g. "/machine/network/hostname")
+// to a dot-separated path (e.g. "machine.network.hostname"). Leading slashes are stripped.
+// RFC 6902 escape sequences (~0 → ~, ~1 → /) are decoded.
+func normaliseJSONPointer(ptr string) string {
+	ptr = strings.TrimPrefix(ptr, "/")
+	parts := strings.Split(ptr, "/")
+	for i, p := range parts {
+		p = strings.ReplaceAll(p, "~1", "/")
+		p = strings.ReplaceAll(p, "~0", "~")
+		parts[i] = p
+	}
+
+	return strings.Join(parts, ".")
+}
+
+// collectPaths recursively walks a decoded YAML map and appends only leaf
+// dot-paths to paths. Intermediate container nodes are not added; only the
+// deepest keys (non-map values, or empty maps) are recorded. This prevents
+// false positives when a patch touches an unrelated sibling subtree whose
+// ancestor happens to share a prefix with a blocked path.
+func collectPaths(prefix string, m map[string]any, paths *[]string) {
+	for k, v := range m {
+		full := k
+		if prefix != "" {
+			full = prefix + "." + k
+		}
+
+		if child, ok := v.(map[string]any); ok && len(child) > 0 {
+			// Non-empty map — recurse without recording this intermediate node.
+			collectPaths(full, child, paths)
+		} else {
+			// Leaf: scalar, array, or empty map (empty map effectively replaces
+			// the subtree, so it must be checked against blocked paths).
+			*paths = append(*paths, full)
+		}
+	}
+}

--- a/internal/tools/patch_blocklist_test.go
+++ b/internal/tools/patch_blocklist_test.go
@@ -1,0 +1,240 @@
+package tools
+
+import (
+	"testing"
+)
+
+func TestPathConflicts(t *testing.T) {
+	tests := []struct {
+		p, b string
+		want bool
+	}{
+		// Exact match.
+		{"machine.security", "machine.security", true},
+		// p is a child of b.
+		{"machine.security.ca", "machine.security", true},
+		{"machine.security.ca.crt", "machine.security", true},
+		// b is a child of p (ancestor block).
+		{"machine", "machine.security.ca", true},
+		{"machine.security", "machine.security.ca", true},
+		// No conflict — different subtrees.
+		{"machine.network", "machine.security", false},
+		{"cluster.etcd", "machine.security", false},
+		// Prefix collision guard (e.g. "machine.sec" must not block "machine.security").
+		{"machine.sec", "machine.security", false},
+		{"machine.securityExtra", "machine.security", false},
+	}
+
+	for _, tc := range tests {
+		got := pathConflicts(tc.p, tc.b)
+		if got != tc.want {
+			t.Errorf("pathConflicts(%q, %q) = %v, want %v", tc.p, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestNormaliseJSONPointer(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/machine/network/hostname", "machine.network.hostname"},
+		{"/machine", "machine"},
+		{"", ""},
+		// RFC 6902 escape sequences.
+		{"/foo~1bar", "foo/bar"},
+		{"/foo~0bar", "foo~bar"},
+	}
+
+	for _, tc := range tests {
+		got := normaliseJSONPointer(tc.input)
+		if got != tc.want {
+			t.Errorf("normaliseJSONPointer(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestExtractPatchPaths_RFC6902(t *testing.T) {
+	patch := `[
+		{"op": "replace", "path": "/machine/network/hostname", "value": "node1"},
+		{"op": "add",     "path": "/machine/certSANs/-",       "value": "192.168.1.1"}
+	]`
+
+	paths, err := extractPatchPaths([]byte(patch))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]bool{
+		"machine.network.hostname": true,
+		"machine.certSANs.-":       true,
+	}
+
+	if len(paths) != len(want) {
+		t.Fatalf("got %d paths, want %d: %v", len(paths), len(want), paths)
+	}
+
+	for _, p := range paths {
+		if !want[p] {
+			t.Errorf("unexpected path %q", p)
+		}
+	}
+}
+
+func TestExtractPatchPaths_StrategicMerge(t *testing.T) {
+	patch := `
+machine:
+  network:
+    hostname: node1
+  certSANs:
+    - 192.168.1.1
+`
+
+	paths, err := extractPatchPaths([]byte(patch))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only leaf paths are collected; intermediate container nodes are skipped.
+	found := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		found[p] = true
+	}
+
+	// machine.network.hostname and machine.certSANs are leaves.
+	// machine and machine.network are intermediate containers — not expected.
+	expected := []string{"machine.network.hostname", "machine.certSANs"}
+	for _, e := range expected {
+		if !found[e] {
+			t.Errorf("expected path %q not found in %v", e, paths)
+		}
+	}
+
+	notExpected := []string{"machine", "machine.network"}
+	for _, e := range notExpected {
+		if found[e] {
+			t.Errorf("intermediate path %q should not be in %v", e, paths)
+		}
+	}
+}
+
+func TestCheckBlockedPaths_NoBlocklist(t *testing.T) {
+	patch := `{"machine": {"network": {"hostname": "node1"}}}`
+	if err := checkBlockedPaths([]byte(patch), nil); err != nil {
+		t.Errorf("expected no error with empty blocklist, got: %v", err)
+	}
+}
+
+func TestCheckBlockedPaths_Blocked(t *testing.T) {
+	patch := `{"machine": {"security": {"ca": {"crt": "CERT"}}}}`
+	blocked := []string{"machine.security"}
+
+	err := checkBlockedPaths([]byte(patch), blocked)
+	if err == nil {
+		t.Fatal("expected error for blocked path, got nil")
+	}
+}
+
+func TestCheckBlockedPaths_Allowed(t *testing.T) {
+	patch := `{"machine": {"network": {"hostname": "node1"}}}`
+	blocked := []string{"machine.security", "cluster.etcd"}
+
+	if err := checkBlockedPaths([]byte(patch), blocked); err != nil {
+		t.Errorf("expected no error for non-blocked path, got: %v", err)
+	}
+}
+
+func TestCheckBlockedPaths_RFC6902Blocked(t *testing.T) {
+	patch := `[{"op": "replace", "path": "/machine/security/ca/crt", "value": "CERT"}]`
+	blocked := []string{"machine.security"}
+
+	err := checkBlockedPaths([]byte(patch), blocked)
+	if err == nil {
+		t.Fatal("expected error for blocked RFC 6902 path, got nil")
+	}
+}
+
+func TestCheckBlockedPaths_RFC6902Allowed(t *testing.T) {
+	patch := `[{"op": "replace", "path": "/machine/network/hostname", "value": "node1"}]`
+	blocked := []string{"machine.security"}
+
+	if err := checkBlockedPaths([]byte(patch), blocked); err != nil {
+		t.Errorf("expected no error for non-blocked RFC 6902 path, got: %v", err)
+	}
+}
+
+func TestCheckBlockedPaths_RFC6902RootPointerBlocked(t *testing.T) {
+	// An RFC 6902 op with path "/" (root document pointer) must be rejected
+	// when any blocklist is active — it would overwrite all config keys.
+	patch := `[{"op": "replace", "path": "/", "value": {}}]`
+	blocked := []string{"machine.security"}
+
+	err := checkBlockedPaths([]byte(patch), blocked)
+	if err == nil {
+		t.Fatal("expected error for root-document RFC 6902 operation, got nil")
+	}
+}
+
+func TestCheckBlockedPaths_RFC6902RootPointerNoBlocklist(t *testing.T) {
+	// Root pointer with no blocklist: no restriction.
+	patch := `[{"op": "replace", "path": "/", "value": {}}]`
+	if err := checkBlockedPaths([]byte(patch), nil); err != nil {
+		t.Errorf("expected no error with empty blocklist, got: %v", err)
+	}
+}
+
+func TestCheckBlockedPaths_RFC6902MoveFromBlockedPath(t *testing.T) {
+	// "move" reads the source via "from"; moving content out of a blocked path
+	// should be rejected even though the destination ("path") is not blocked.
+	patch := `[{"op": "move", "from": "/machine/security", "path": "/machine/network"}]`
+	blocked := []string{"machine.security"}
+
+	err := checkBlockedPaths([]byte(patch), blocked)
+	if err == nil {
+		t.Fatal("expected error: move from blocked path should be rejected, got nil")
+	}
+}
+
+func TestCheckBlockedPaths_RFC6902CopyFromBlockedPath(t *testing.T) {
+	// "copy" reads from the "from" source; copying a blocked path must be rejected.
+	patch := `[{"op": "copy", "from": "/machine/security/ca", "path": "/machine/network/ca"}]`
+	blocked := []string{"machine.security"}
+
+	err := checkBlockedPaths([]byte(patch), blocked)
+	if err == nil {
+		t.Fatal("expected error: copy from blocked path should be rejected, got nil")
+	}
+}
+
+func TestCheckBlockedPaths_RFC6902MoveToBlockedPath(t *testing.T) {
+	// "move" that targets a blocked path must also be rejected (destination is blocked).
+	patch := `[{"op": "move", "from": "/machine/network/hostname", "path": "/machine/security/hostname"}]`
+	blocked := []string{"machine.security"}
+
+	err := checkBlockedPaths([]byte(patch), blocked)
+	if err == nil {
+		t.Fatal("expected error: move to blocked path should be rejected, got nil")
+	}
+}
+
+func TestCheckBlockedPaths_RFC6902MoveUnrelatedPaths(t *testing.T) {
+	// "move" between two unblocked paths should be allowed.
+	patch := `[{"op": "move", "from": "/machine/network/hostname", "path": "/machine/network/alias"}]`
+	blocked := []string{"machine.security"}
+
+	if err := checkBlockedPaths([]byte(patch), blocked); err != nil {
+		t.Errorf("expected no error for move between non-blocked paths, got: %v", err)
+	}
+}
+
+func TestCheckBlockedPaths_EmptyMapClearsBlockedPath(t *testing.T) {
+	// An empty map value for a blocked key effectively clears that subtree.
+	// It must be treated as a leaf and rejected.
+	patch := `{"machine": {"security": {}}}`
+	blocked := []string{"machine.security"}
+
+	err := checkBlockedPaths([]byte(patch), blocked)
+	if err == nil {
+		t.Fatal("expected error: empty-map clear of blocked path should be rejected, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `TALOS_MCP_BLOCKED_CONFIG_PATHS` env var: comma-separated dot-path prefixes that `talos_patch_config` refuses to modify (e.g. `machine.security,cluster.etcd`)
- Path matching covers exact, child, and parent paths; strategic merge patches use leaf-only extraction to avoid false positives from intermediate container nodes
- RFC 6902 JSON Patches are normalised from pointer notation (`/machine/security`) to dot notation; RFC 6902 escape sequences decoded per spec
- `talos_apply_config` is disabled entirely when the blocklist is active (full-document replace cannot be safely restricted to a subset of paths)
- RFC 6902 root-document pointer (`/`) is rejected when any blocklist entry is set
- Both dry-run and live patches are subject to the blocklist (no bypass via dry-run)

## Test plan

- [ ] `make check` passes (all 6 packages green)
- [ ] `TestPathConflicts` — exact, child, parent, and prefix-collision cases
- [ ] `TestCheckBlockedPaths_*` — no blocklist, blocked, allowed, RFC 6902 variants, root pointer
- [ ] `TestExtractPatchPaths_RFC6902` and `TestExtractPatchPaths_StrategicMerge`
- [ ] Manual: set `TALOS_MCP_BLOCKED_CONFIG_PATHS=machine.security` and attempt a patch targeting that path — expect rejection

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)