### PR TITLE
feat(tools)!: declare output schemas and return structured content for read-only tools

### DIFF
--- a/cmd/talos-mcp/main.go
+++ b/cmd/talos-mcp/main.go
@@ -180,69 +180,80 @@ func main() {
 	// ── Read-only tools ──────────────────────────────────────────────────────
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_resource_definitions",
-		Description: "List all available Talos resource types with their aliases. Call this first to discover what resources can be queried with talos_get.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_resource_definitions",
+		Description:  "List all available Talos resource types with their aliases. Call this first to discover what resources can be queried with talos_get.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.ResourceDefinitionsOutputSchema(),
 	}, h.HandleResourceDefinitions)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_get",
-		Description: "Get Talos resources by type. Use talos_resource_definitions to discover available types. Examples: MachineStatus, Member, NodeAddress, LinkStatus, Route, Service, Extension.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_get",
+		Description:  "Get Talos resources by type. Use talos_resource_definitions to discover available types. Examples: MachineStatus, Member, NodeAddress, LinkStatus, Route, Service, Extension.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.GetResourceOutputSchema(),
 	}, h.HandleGetResource)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_version",
-		Description: "Get Talos version information from the target nodes.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_version",
+		Description:  "Get Talos version information from the target nodes.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.VersionOutputSchema(),
 	}, h.HandleVersion)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_services",
-		Description: "List all Talos services and their current state (running, stopped, health status).",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_services",
+		Description:  "List all Talos services and their current state (running, stopped, health status).",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.ServicesOutputSchema(),
 	}, h.HandleServices)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_containers",
-		Description: "List containers running in the specified namespace. Defaults to the 'k8s.io' namespace (Kubernetes containers).",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_containers",
+		Description:  "List containers running in the specified namespace. Defaults to the 'k8s.io' namespace (Kubernetes containers).",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.ContainersOutputSchema(),
 	}, h.HandleContainers)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_processes",
-		Description: "List running processes on the target nodes.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_processes",
+		Description:  "List running processes on the target nodes.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.ProcessesOutputSchema(),
 	}, h.HandleProcesses)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_health",
-		Description: "Check the health of the Talos cluster (etcd, Kubernetes API, node readiness). Waits up to wait_timeout for all checks to pass.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_health",
+		Description:  "Check the health of the Talos cluster (etcd, Kubernetes API, node readiness). Waits up to wait_timeout for all checks to pass.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.HealthOutputSchema(),
 	}, h.HandleHealth)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_logs",
-		Description: "Stream recent service logs from the target nodes. Returns the last tail_lines lines without following.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_logs",
+		Description:  "Stream recent service logs from the target nodes. Returns the last tail_lines lines without following.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.LogsOutputSchema(),
 	}, h.HandleLogs)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_dmesg",
-		Description: "Read kernel ring buffer (dmesg) messages from the target nodes.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_dmesg",
+		Description:  "Read kernel ring buffer (dmesg) messages from the target nodes.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.DmesgOutputSchema(),
 	}, h.HandleDmesg)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_events",
-		Description: "Fetch recent Talos runtime events (node lifecycle, service changes, config changes). Returns the last tail_count events.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_events",
+		Description:  "Fetch recent Talos runtime events (node lifecycle, service changes, config changes). Returns the last tail_count events.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.EventsOutputSchema(),
 	}, h.HandleEvents)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_etcd",
-		Description: "Query etcd cluster information. Use subcommand='members' (default) or subcommand='status'.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_etcd",
+		Description:  "Query etcd cluster information. Use subcommand='members' (default) or subcommand='status'.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.EtcdOutputSchema(),
 	}, h.HandleEtcd)
 
 	mcp.AddTool(server, &mcp.Tool{
@@ -251,19 +262,22 @@ func main() {
 			"Returns the file path and byte count on success. " +
 			"Requires exactly one control plane node in nodes[]. " +
 			"Snapshot may take up to 5 minutes for large clusters.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.EtcdSnapshotOutputSchema(),
 	}, h.HandleEtcdSnapshot)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_list_files",
-		Description: "List files and directories on a target node filesystem.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_list_files",
+		Description:  "List files and directories on a target node filesystem.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.ListFilesOutputSchema(),
 	}, h.HandleListFiles)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "talos_read_file",
-		Description: "Read the contents of a file from a target node filesystem (e.g. /etc/os-release, /etc/machine-config.yaml).",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Name:         "talos_read_file",
+		Description:  "Read the contents of a file from a target node filesystem (e.g. /etc/os-release, /etc/machine-config.yaml).",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.ReadFileOutputSchema(),
 	}, h.HandleReadFile)
 
 	mcp.AddTool(server, &mcp.Tool{
@@ -272,7 +286,8 @@ func main() {
 			"Use mode='metal' (default), 'cloud', or 'container'. " +
 			"Set strict=true to treat warnings as errors. " +
 			"Returns {valid, mode, strict, warnings} and on failure also {errors}.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: closedWorld},
+		OutputSchema: tools.ValidateOutputSchema(),
 	}, h.HandleValidate)
 
 	// ── Write / mutating tools ───────────────────────────────────────────────

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cosi-project/runtime v1.14.1
+	github.com/google/jsonschema-go v0.4.2
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/siderolabs/talos/pkg/machinery v1.12.6
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
@@ -30,7 +31,6 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/google/cel-go v0.26.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/internal/tools/etcd.go
+++ b/internal/tools/etcd.go
@@ -8,11 +8,32 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 
 	"github.com/Nosmoht/talos-mcp-server/internal/talos"
 )
+
+// etcdSnapshotResult is the structured output for talos_etcd_snapshot.
+type etcdSnapshotResult struct {
+	Path  string `json:"path"`
+	Bytes int64  `json:"bytes"`
+}
+
+// etcdOutputSchema is permissive: the handler returns one of two Talos
+// protobuf types (member list or status) depending on the subcommand, and
+// reflective derivation over protoimpl-embedded structs is noisy.
+var (
+	etcdOutputSchema         = permissiveObjectSchema()
+	etcdSnapshotOutputSchema = mustDeriveSchema[etcdSnapshotResult]()
+)
+
+// EtcdOutputSchema returns the JSON schema for HandleEtcd.
+func EtcdOutputSchema() *jsonschema.Schema { return etcdOutputSchema }
+
+// EtcdSnapshotOutputSchema returns the JSON schema for HandleEtcdSnapshot.
+func EtcdSnapshotOutputSchema() *jsonschema.Schema { return etcdSnapshotOutputSchema }
 
 // EtcdArgs defines input for talos_etcd.
 type EtcdArgs struct {
@@ -121,8 +142,5 @@ func (h *Handlers) HandleEtcdSnapshot(ctx context.Context, req *mcp.CallToolRequ
 
 	notifyProgress(ctx, req, "Snapshot complete", 3, 3)
 
-	return jsonResult(map[string]any{
-		"path":  args.Path,
-		"bytes": n,
-	})
+	return jsonResult(etcdSnapshotResult{Path: args.Path, Bytes: n})
 }

--- a/internal/tools/files.go
+++ b/internal/tools/files.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 
@@ -20,6 +21,42 @@ const (
 	defaultReadMaxBytes = 32768 // 32 KB
 	maxListEntries      = 10000
 )
+
+// fileEntry describes a single filesystem entry returned by talos_list_files.
+type fileEntry struct {
+	Name         string `json:"name"`
+	RelativeName string `json:"relative_name,omitzero"`
+	Size         int64  `json:"size"`
+	IsDir        bool   `json:"is_dir"`
+	Mode         string `json:"mode,omitzero"`
+}
+
+// listFilesResult is the structured output for talos_list_files.
+type listFilesResult struct {
+	Path       string            `json:"path"`
+	Entries    []fileEntry       `json:"entries"`
+	Truncated  bool              `json:"truncated"`
+	NodeErrors map[string]string `json:"node_errors,omitzero"`
+}
+
+// readFileResult is the structured output for talos_read_file.
+type readFileResult struct {
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+	Truncated bool   `json:"truncated"`
+	MaxBytes  int    `json:"max_bytes"`
+}
+
+var (
+	listFilesOutputSchema = mustDeriveSchema[listFilesResult]()
+	readFileOutputSchema  = mustDeriveSchema[readFileResult]()
+)
+
+// ListFilesOutputSchema returns the JSON schema for HandleListFiles.
+func ListFilesOutputSchema() *jsonschema.Schema { return listFilesOutputSchema }
+
+// ReadFileOutputSchema returns the JSON schema for HandleReadFile.
+func ReadFileOutputSchema() *jsonschema.Schema { return readFileOutputSchema }
 
 // ListFilesArgs defines input for talos_list_files.
 type ListFilesArgs struct {
@@ -64,15 +101,7 @@ func (h *Handlers) HandleListFiles(ctx context.Context, _ *mcp.CallToolRequest, 
 		return nil, nil, fmt.Errorf("list files %q: %w", path, err)
 	}
 
-	type fileEntry struct {
-		Name         string `json:"name"`
-		RelativeName string `json:"relative_name,omitempty"`
-		Size         int64  `json:"size"`
-		IsDir        bool   `json:"is_dir"`
-		Mode         string `json:"mode,omitempty"`
-	}
-
-	var files []fileEntry
+	files := []fileEntry{}
 
 	nodeErrors := make(map[string]string)
 
@@ -133,17 +162,22 @@ func (h *Handlers) HandleListFiles(ctx context.Context, _ *mcp.CallToolRequest, 
 		return nil, nil, fmt.Errorf("marshal JSON: %w", err)
 	}
 
-	result := string(out)
+	text := string(out)
 	if truncated {
-		result += fmt.Sprintf("\n\n[truncated at %d entries]", maxListEntries)
+		text += fmt.Sprintf("\n\n[truncated at %d entries]", maxListEntries)
 	}
 
 	if len(nodeErrors) > 0 {
 		errJSON, _ := json.Marshal(nodeErrors)
-		result += "\n\n[node errors: " + string(errJSON) + "]"
+		text += "\n\n[node errors: " + string(errJSON) + "]"
 	}
 
-	return textResult(result), nil, nil
+	dto := listFilesResult{Path: listPath, Entries: files, Truncated: truncated}
+	if len(nodeErrors) > 0 {
+		dto.NodeErrors = nodeErrors
+	}
+
+	return jsonWithTextResult(dto, text)
 }
 
 // HandleReadFile implements the talos_read_file tool.
@@ -194,7 +228,14 @@ func (h *Handlers) HandleReadFile(ctx context.Context, _ *mcp.CallToolRequest, a
 		fmt.Fprintf(&sb, "\n\n[truncated at %d bytes]", maxBytes)
 	}
 
-	return textResult(sb.String()), nil, nil
+	dto := readFileResult{
+		Path:      args.Path,
+		Content:   content,
+		Truncated: truncated,
+		MaxBytes:  maxBytes,
+	}
+
+	return jsonWithTextResult(dto, sb.String())
 }
 
 // ParseAllowedPaths parses a comma-separated list of path prefixes into a slice.

--- a/internal/tools/helpers.go
+++ b/internal/tools/helpers.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/Nosmoht/talos-mcp-server/internal/talos"
@@ -77,14 +78,44 @@ func textResult(text string) *mcp.CallToolResult {
 	}
 }
 
-// jsonResult marshals v to compact JSON and returns the MCP tool result tuple.
+// jsonResult returns v as the structured output of the tool call.
+// The go-sdk auto-populates StructuredContent from the second return value and
+// renders a JSON-text Content fallback for clients that don't consume
+// structured output. See go-sdk mcp.CallToolResult.StructuredContent.
 func jsonResult(v any) (*mcp.CallToolResult, any, error) {
-	out, err := json.Marshal(v)
-	if err != nil {
-		return nil, nil, fmt.Errorf("marshal JSON: %w", err)
-	}
+	return nil, v, nil
+}
 
-	return textResult(string(out)), nil, nil
+// jsonWithTextResult returns v as structured output and humanText as a
+// human-readable Content block. Use for tools whose output is fundamentally
+// prose (logs, file contents) but benefits from a machine-readable schema.
+// The MCP spec's dual-content pattern:
+// https://modelcontextprotocol.io/specification/draft/server/tools#structured-content.
+func jsonWithTextResult(v any, humanText string) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: humanText}},
+	}, v, nil
+}
+
+// mustDeriveSchema derives a JSON schema for type T or panics. Intended for
+// package-level var initialisation; the output_schema_test.go ensures every
+// accessor resolves in CI so panics cannot reach production.
+func mustDeriveSchema[T any]() *jsonschema.Schema {
+	s, err := jsonschema.For[T](nil)
+	if err != nil {
+		panic(fmt.Sprintf("derive schema for %T: %v", *new(T), err))
+	}
+	return s
+}
+
+// permissiveObjectSchema returns a schema that accepts any JSON object.
+// Used for tools whose output shape is dictated by upstream Talos protobufs
+// (whose reflective schema is noisy) or is genuinely polymorphic.
+func permissiveObjectSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:                 "object",
+		AdditionalProperties: &jsonschema.Schema{},
+	}
 }
 
 // auditLog emits a structured audit record at INFO level.

--- a/internal/tools/helpers_test.go
+++ b/internal/tools/helpers_test.go
@@ -1,0 +1,71 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestJSONResult_ReturnsStructured verifies that jsonResult hands the value
+// straight through as the second return (StructuredContent), with no Content
+// text wrapping. The go-sdk auto-populates Content with JSON text; the helper
+// must NOT pre-populate it.
+func TestJSONResult_ReturnsStructured(t *testing.T) {
+	type payload struct {
+		Answer int `json:"answer"`
+	}
+
+	p := payload{Answer: 42}
+
+	res, out, err := jsonResult(p)
+	if err != nil {
+		t.Fatalf("jsonResult: unexpected error %v", err)
+	}
+	if res != nil {
+		t.Fatalf("jsonResult: expected nil *CallToolResult, got %+v", res)
+	}
+	got, ok := out.(payload)
+	if !ok {
+		t.Fatalf("jsonResult: out type = %T, want payload", out)
+	}
+	if got != p {
+		t.Fatalf("jsonResult: out = %+v, want %+v", got, p)
+	}
+}
+
+// TestJSONWithTextResult_DualContent verifies the dual-content path used by
+// the 4 text-heavy tools: Content carries human-readable prose, StructuredContent
+// carries the typed DTO. Both must ride on the wire.
+func TestJSONWithTextResult_DualContent(t *testing.T) {
+	type payload struct {
+		Lines []string `json:"lines"`
+	}
+
+	p := payload{Lines: []string{"a", "b"}}
+	text := "a\nb"
+
+	res, out, err := jsonWithTextResult(p, text)
+	if err != nil {
+		t.Fatalf("jsonWithTextResult: unexpected error %v", err)
+	}
+	if res == nil {
+		t.Fatal("jsonWithTextResult: expected non-nil *CallToolResult")
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("jsonWithTextResult: Content length = %d, want 1", len(res.Content))
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("jsonWithTextResult: Content[0] type = %T, want *mcp.TextContent", res.Content[0])
+	}
+	if tc.Text != text {
+		t.Fatalf("jsonWithTextResult: Content[0].Text = %q, want %q", tc.Text, text)
+	}
+	got, ok := out.(payload)
+	if !ok {
+		t.Fatalf("jsonWithTextResult: out type = %T, want payload", out)
+	}
+	if len(got.Lines) != 2 || got.Lines[0] != "a" || got.Lines[1] != "b" {
+		t.Fatalf("jsonWithTextResult: out = %+v, want %+v", got, p)
+	}
+}

--- a/internal/tools/logs.go
+++ b/internal/tools/logs.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	commonapi "github.com/siderolabs/talos/pkg/machinery/api/common"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
@@ -23,6 +24,48 @@ const (
 	defaultEventsTimeout         = 5 * time.Second
 	defaultLogsNamespace         = "system"
 )
+
+// logsResult is the structured output for talos_logs.
+type logsResult struct {
+	Service    string            `json:"service"`
+	Lines      []string          `json:"lines"`
+	NodeErrors map[string]string `json:"node_errors,omitzero"`
+}
+
+// dmesgResult is the structured output for talos_dmesg.
+type dmesgResult struct {
+	Lines      []string          `json:"lines"`
+	NodeErrors map[string]string `json:"node_errors,omitzero"`
+}
+
+// eventEntry is a single Talos runtime event.
+type eventEntry struct {
+	Node    string `json:"node"`
+	TypeURL string `json:"type_url"`
+	ID      string `json:"id"`
+	Payload string `json:"payload"`
+}
+
+// eventsResult is the structured output for talos_events.
+type eventsResult struct {
+	Count  int          `json:"count"`
+	Events []eventEntry `json:"events"`
+}
+
+var (
+	logsOutputSchema   = mustDeriveSchema[logsResult]()
+	dmesgOutputSchema  = mustDeriveSchema[dmesgResult]()
+	eventsOutputSchema = mustDeriveSchema[eventsResult]()
+)
+
+// LogsOutputSchema returns the JSON schema for HandleLogs.
+func LogsOutputSchema() *jsonschema.Schema { return logsOutputSchema }
+
+// DmesgOutputSchema returns the JSON schema for HandleDmesg.
+func DmesgOutputSchema() *jsonschema.Schema { return dmesgOutputSchema }
+
+// EventsOutputSchema returns the JSON schema for HandleEvents.
+func EventsOutputSchema() *jsonschema.Schema { return eventsOutputSchema }
 
 // LogsArgs defines input for talos_logs.
 type LogsArgs struct {
@@ -62,7 +105,7 @@ func (h *Handlers) HandleLogs(ctx context.Context, _ *mcp.CallToolRequest, args 
 		return nil, nil, fmt.Errorf("logs for %q: %w", args.ServiceName, err)
 	}
 
-	var lines []string
+	lines := []string{}
 
 	nodeErrors := make(map[string]string)
 
@@ -102,13 +145,18 @@ func (h *Handlers) HandleLogs(ctx context.Context, _ *mcp.CallToolRequest, args 
 		return nil, nil, fmt.Errorf("logs stream for %q: %w", args.ServiceName, streamErr)
 	}
 
-	result := strings.Join(lines, "\n")
+	text := strings.Join(lines, "\n")
 	if len(nodeErrors) > 0 {
 		errJSON, _ := json.Marshal(nodeErrors)
-		result += "\n\n[node errors: " + string(errJSON) + "]"
+		text += "\n\n[node errors: " + string(errJSON) + "]"
 	}
 
-	return textResult(result), nil, nil
+	dto := logsResult{Service: args.ServiceName, Lines: lines}
+	if len(nodeErrors) > 0 {
+		dto.NodeErrors = nodeErrors
+	}
+
+	return jsonWithTextResult(dto, text)
 }
 
 // DmesgArgs defines input for talos_dmesg.
@@ -185,17 +233,26 @@ func (h *Handlers) HandleDmesg(ctx context.Context, _ *mcp.CallToolRequest, args
 		return nil, nil, fmt.Errorf("dmesg stream: %w", streamErr)
 	}
 
-	result := strings.Join(lines, "\n")
+	text := strings.Join(lines, "\n")
 	if len(lines) == 0 {
-		result = "(no dmesg output)"
+		text = "(no dmesg output)"
 	}
 
 	if len(nodeErrors) > 0 {
 		errJSON, _ := json.Marshal(nodeErrors)
-		result += "\n\n[node errors: " + string(errJSON) + "]"
+		text += "\n\n[node errors: " + string(errJSON) + "]"
 	}
 
-	return textResult(result), nil, nil
+	if lines == nil {
+		lines = []string{}
+	}
+
+	dto := dmesgResult{Lines: lines}
+	if len(nodeErrors) > 0 {
+		dto.NodeErrors = nodeErrors
+	}
+
+	return jsonWithTextResult(dto, text)
 }
 
 // EventsArgs defines input for talos_events.
@@ -220,14 +277,7 @@ func (h *Handlers) HandleEvents(ctx context.Context, _ *mcp.CallToolRequest, arg
 	collectCtx, cancel := context.WithTimeout(nodesCtx, defaultEventsTimeout)
 	defer cancel()
 
-	type eventEntry struct {
-		Node    string `json:"node"`
-		TypeURL string `json:"type_url"`
-		ID      string `json:"id"`
-		Payload string `json:"payload"`
-	}
-
-	var events []eventEntry
+	events := []eventEntry{}
 
 	// EventsWatch streams forever — we stop it via context timeout.
 	// WithTailEvents sends the last N historical events, then continues streaming new ones.
@@ -256,10 +306,5 @@ func (h *Handlers) HandleEvents(ctx context.Context, _ *mcp.CallToolRequest, arg
 		return nil, nil, fmt.Errorf("events watch: %w", err)
 	}
 
-	type result struct {
-		Count  int          `json:"count"`
-		Events []eventEntry `json:"events"`
-	}
-
-	return jsonResult(result{Count: len(events), Events: events})
+	return jsonResult(eventsResult{Count: len(events), Events: events})
 }

--- a/internal/tools/output_schema_test.go
+++ b/internal/tools/output_schema_test.go
@@ -1,0 +1,116 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+// TestOutputSchemas_AllAccessorsResolve calls every output-schema accessor
+// and resolves the resulting schema. Two purposes:
+//  1. Catch any mustDeriveSchema panic in CI rather than at production startup.
+//  2. Ensure each schema is structurally valid per JSON Schema 2020-12.
+//
+// This test is the CI-enforceable half of plan step 4.2.
+func TestOutputSchemas_AllAccessorsResolve(t *testing.T) {
+	cases := map[string]func() *jsonschema.Schema{
+		"talos_resource_definitions": ResourceDefinitionsOutputSchema,
+		"talos_get":                  GetResourceOutputSchema,
+		"talos_version":              VersionOutputSchema,
+		"talos_services":             ServicesOutputSchema,
+		"talos_containers":           ContainersOutputSchema,
+		"talos_processes":            ProcessesOutputSchema,
+		"talos_health":               HealthOutputSchema,
+		"talos_logs":                 LogsOutputSchema,
+		"talos_dmesg":                DmesgOutputSchema,
+		"talos_events":               EventsOutputSchema,
+		"talos_etcd":                 EtcdOutputSchema,
+		"talos_etcd_snapshot":        EtcdSnapshotOutputSchema,
+		"talos_list_files":           ListFilesOutputSchema,
+		"talos_read_file":            ReadFileOutputSchema,
+		"talos_validate":             ValidateOutputSchema,
+	}
+
+	for tool, accessor := range cases {
+		t.Run(tool, func(t *testing.T) {
+			s := accessor()
+			if s == nil {
+				t.Fatal("accessor returned nil schema")
+			}
+			if s.Type != "object" {
+				t.Fatalf("schema type = %q, want \"object\" (MCP spec requires structuredContent to be a JSON object)", s.Type)
+			}
+			if _, err := s.Resolve(&jsonschema.ResolveOptions{}); err != nil {
+				t.Fatalf("schema failed to resolve: %v", err)
+			}
+		})
+	}
+}
+
+// TestOutputSchema_ValidatesPayload satisfies issue #145 acceptance criterion #3
+// programmatically: marshals a fixture payload for three tools and validates it
+// against the declared schema. Runs in CI — no manual Inspector session needed.
+func TestOutputSchema_ValidatesPayload(t *testing.T) {
+	ctx := context.Background()
+
+	type fixture struct {
+		name    string
+		schema  *jsonschema.Schema
+		payload any
+	}
+
+	fixtures := []fixture{
+		{
+			name:   "talos_validate",
+			schema: ValidateOutputSchema(),
+			payload: validateResult{
+				Valid:    true,
+				Mode:     "metal",
+				Strict:   false,
+				Warnings: []string{},
+			},
+		},
+		{
+			name:   "talos_health",
+			schema: HealthOutputSchema(),
+			payload: healthResult{
+				Messages: []string{"etcd is healthy", "nodes are ready"},
+			},
+		},
+		{
+			name:   "talos_etcd_snapshot",
+			schema: EtcdSnapshotOutputSchema(),
+			payload: etcdSnapshotResult{
+				Path:  "/tmp/etcd.db",
+				Bytes: 12345,
+			},
+		},
+	}
+
+	for _, fx := range fixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			resolved, err := fx.schema.Resolve(&jsonschema.ResolveOptions{})
+			if err != nil {
+				t.Fatalf("resolve schema: %v", err)
+			}
+
+			raw, err := json.Marshal(fx.payload)
+			if err != nil {
+				t.Fatalf("marshal payload: %v", err)
+			}
+
+			var value any
+			if err := json.Unmarshal(raw, &value); err != nil {
+				t.Fatalf("unmarshal payload: %v", err)
+			}
+
+			if err := resolved.Validate(value); err != nil {
+				t.Fatalf("payload failed schema validation: %v\npayload=%s", err, raw)
+			}
+
+			_ = ctx
+		})
+	}
+}

--- a/internal/tools/resources.go
+++ b/internal/tools/resources.go
@@ -7,11 +7,58 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/Nosmoht/talos-mcp-server/internal/marshal"
 	"github.com/Nosmoht/talos-mcp-server/internal/talos"
 )
+
+// resourceList is the envelope returned by HandleGetResource. The MCP spec
+// requires structuredContent to be a JSON object, so the polymorphic list of
+// resources is wrapped in an object with a single "items" array.
+type resourceList struct {
+	Items []map[string]any `json:"items"`
+}
+
+// resourceDefinitionList is the envelope returned by HandleResourceDefinitions.
+type resourceDefinitionList struct {
+	Items []map[string]any `json:"items"`
+}
+
+// getResourceOutputSchema is hand-written rather than reflective: items are
+// genuinely polymorphic (MachineStatus, NodeAddress, Route have different
+// shapes). The permissive item schema matches Kubernetes' unstructured.Unstructured
+// convention for heterogeneous resource lists.
+var getResourceOutputSchema = &jsonschema.Schema{
+	Type: "object",
+	Properties: map[string]*jsonschema.Schema{
+		"items": {
+			Type:  "array",
+			Items: &jsonschema.Schema{Type: "object", AdditionalProperties: &jsonschema.Schema{}},
+		},
+	},
+	Required: []string{"items"},
+}
+
+// GetResourceOutputSchema returns the JSON schema for HandleGetResource.
+func GetResourceOutputSchema() *jsonschema.Schema { return getResourceOutputSchema }
+
+// resourceDefinitionsOutputSchema: same permissive shape as getResourceOutputSchema,
+// since each definition's marshaled map is also built ad-hoc.
+var resourceDefinitionsOutputSchema = &jsonschema.Schema{
+	Type: "object",
+	Properties: map[string]*jsonschema.Schema{
+		"items": {
+			Type:  "array",
+			Items: &jsonschema.Schema{Type: "object", AdditionalProperties: &jsonschema.Schema{}},
+		},
+	},
+	Required: []string{"items"},
+}
+
+// ResourceDefinitionsOutputSchema returns the JSON schema for HandleResourceDefinitions.
+func ResourceDefinitionsOutputSchema() *jsonschema.Schema { return resourceDefinitionsOutputSchema }
 
 // GetResourceArgs defines input for talos_get.
 type GetResourceArgs struct {
@@ -77,7 +124,11 @@ func (h *Handlers) HandleGetResource(ctx context.Context, _ *mcp.CallToolRequest
 		}
 	}
 
-	return jsonResult(results)
+	if results == nil {
+		results = []map[string]any{}
+	}
+
+	return jsonResult(resourceList{Items: results})
 }
 
 // HandleResourceDefinitions implements the talos_resource_definitions tool.
@@ -90,11 +141,11 @@ func (h *Handlers) HandleResourceDefinitions(ctx context.Context, _ *mcp.CallToo
 		return nil, nil, fmt.Errorf("list resource definitions: %w", err)
 	}
 
-	var defs []map[string]any
+	defs := []map[string]any{}
 
 	for rd := range list.All() {
 		defs = append(defs, marshal.ResourceDefinition(rd))
 	}
 
-	return jsonResult(defs)
+	return jsonResult(resourceDefinitionList{Items: defs})
 }

--- a/internal/tools/system.go
+++ b/internal/tools/system.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	clusterapi "github.com/siderolabs/talos/pkg/machinery/api/cluster"
 	commonapi "github.com/siderolabs/talos/pkg/machinery/api/common"
@@ -19,6 +20,40 @@ const (
 	defaultHealthWaitTimeout       = 2 * time.Minute
 	defaultHealthWaitTimeoutBuffer = 10 * time.Second
 )
+
+// healthResult is the structured output for talos_health.
+type healthResult struct {
+	Messages []string `json:"messages"`
+}
+
+// Schemas for talos_version, talos_services, talos_containers, talos_processes
+// use permissive object schemas because the underlying responses are Talos SDK
+// protobuf types. Reflective derivation over protobuf-generated structs with
+// embedded protoimpl.MessageState is noisy and risks runtime-validation
+// mismatches against actual marshaled payloads. Permissive schemas meet the
+// MCP spec's object-only constraint without guessing the exact shape.
+var (
+	versionOutputSchema    = permissiveObjectSchema()
+	servicesOutputSchema   = permissiveObjectSchema()
+	containersOutputSchema = permissiveObjectSchema()
+	processesOutputSchema  = permissiveObjectSchema()
+	healthOutputSchema     = mustDeriveSchema[healthResult]()
+)
+
+// VersionOutputSchema returns the JSON schema for HandleVersion.
+func VersionOutputSchema() *jsonschema.Schema { return versionOutputSchema }
+
+// ServicesOutputSchema returns the JSON schema for HandleServices.
+func ServicesOutputSchema() *jsonschema.Schema { return servicesOutputSchema }
+
+// ContainersOutputSchema returns the JSON schema for HandleContainers.
+func ContainersOutputSchema() *jsonschema.Schema { return containersOutputSchema }
+
+// ProcessesOutputSchema returns the JSON schema for HandleProcesses.
+func ProcessesOutputSchema() *jsonschema.Schema { return processesOutputSchema }
+
+// HealthOutputSchema returns the JSON schema for HandleHealth.
+func HealthOutputSchema() *jsonschema.Schema { return healthOutputSchema }
 
 // ContainersArgs defines input for talos_containers.
 type ContainersArgs struct {
@@ -151,7 +186,7 @@ func (h *Handlers) HandleHealth(ctx context.Context, req *mcp.CallToolRequest, a
 		return nil, nil, fmt.Errorf("health check: %w", err)
 	}
 
-	var messages []string
+	messages := []string{}
 
 	var i float64
 
@@ -188,10 +223,6 @@ func (h *Handlers) HandleHealth(ctx context.Context, req *mcp.CallToolRequest, a
 	// for upgrades and config patches.
 	if streamErr != nil {
 		return nil, nil, fmt.Errorf("health check failed: %w", streamErr)
-	}
-
-	type healthResult struct {
-		Messages []string `json:"messages"`
 	}
 
 	return jsonResult(healthResult{Messages: messages})

--- a/internal/tools/validate.go
+++ b/internal/tools/validate.go
@@ -4,10 +4,28 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/validation"
 )
+
+// validateResult is the structured output for talos_validate. Note: the prior
+// inline-map shape used a singular "error" string field on failure; the new
+// schema exposes "errors" as an array of strings for consistency with
+// "warnings". Callers that parsed the prior key must migrate.
+type validateResult struct {
+	Valid    bool     `json:"valid"`
+	Mode     string   `json:"mode"`
+	Strict   bool     `json:"strict"`
+	Warnings []string `json:"warnings"`
+	Errors   []string `json:"errors,omitzero"`
+}
+
+var validateOutputSchema = mustDeriveSchema[validateResult]()
+
+// ValidateOutputSchema returns the JSON schema for HandleValidate.
+func ValidateOutputSchema() *jsonschema.Schema { return validateOutputSchema }
 
 // ValidateArgs defines input for talos_validate.
 type ValidateArgs struct {
@@ -68,14 +86,14 @@ func (h *Handlers) HandleValidate(_ context.Context, _ *mcp.CallToolRequest, arg
 		warnings = []string{}
 	}
 
-	result := map[string]any{
-		"valid":    valErr == nil,
-		"mode":     mode.String(),
-		"strict":   args.Strict,
-		"warnings": warnings,
+	result := validateResult{
+		Valid:    valErr == nil,
+		Mode:     mode.String(),
+		Strict:   args.Strict,
+		Warnings: warnings,
 	}
 	if valErr != nil {
-		result["error"] = valErr.Error()
+		result.Errors = []string{valErr.Error()}
 	}
 
 	return jsonResult(result)


### PR DESCRIPTION
## Summary

- Every read-only tool now declares `OutputSchema` and returns `StructuredContent` via the go-sdk's `ToolHandlerFor` Out return value. The `jsonResult` helper was flipped from wrapping JSON as `TextContent` to handing the typed value to the SDK, which auto-renders a JSON-text Content fallback (MCP spec dual-content pattern).
- The 4 text-heavy tools (`talos_logs`, `talos_dmesg`, `talos_read_file`, `talos_list_files`) use a new `jsonWithTextResult` helper that preserves the original human-readable prose in `Content` while adding `structuredContent` — additive only, no text regression.
- Closes #145.

## ⚠ BREAKING CHANGE

Three read-only tool response shapes change. This is why the commit is tagged `feat(tools)!:`.

1. **`talos_validate`** on failure: key rename + type change.
   - Before: `{"valid":false,"warnings":[],"error":"<msg>"}`
   - After: `{"valid":false,"warnings":[],"errors":["<msg>"]}`
   - Migration: parse `result.errors[0]` instead of `result.error`.

2. **`talos_get`**: response wrapped in `{items:[...]}`.
   - Before: `[{…}, {…}]`
   - After: `{"items":[{…}, {…}]}`
   - Migration: access `result.items` instead of `result`.
   - Rationale: MCP spec requires `structuredContent` to be a JSON object (go-sdk `server.go:264-273` panics on non-object schemas).

3. **`talos_resource_definitions`**: same envelope change as `talos_get`.

The four text tools preserve their original `Content[0].Text` prose unchanged; `structuredContent` is purely additive.

## Schema strategy

- **Reflective** (`jsonschema.For[T]()`): typed DTOs under our control (`logsResult`, `dmesgResult`, `listFilesResult`, `readFileResult`, `etcdSnapshotResult`, `validateResult`, `healthResult`, `eventsResult`).
- **Permissive** (`{type:"object", additionalProperties:{}}`): 5 tools returning Talos SDK protobuf types (`talos_version`, `talos_services`, `talos_containers`, `talos_processes`, `talos_etcd`). Reflecting over `protoimpl.MessageState` is noisy and would risk runtime-validation mismatches; permissive schemas meet the MCP spec's object-only constraint without over-promising shape.
- **Hand-written envelopes**: `talos_get` and `talos_resource_definitions` (polymorphic item payloads — matches Kubernetes' `unstructured.Unstructured` convention).

## Test plan

- [x] `make check` green (fmt + vet + lint + `go test -race`).
- [x] New `TestJSONResult_ReturnsStructured` pins `jsonResult(v) == (nil, v, nil)`.
- [x] New `TestJSONWithTextResult_DualContent` pins `Content = prose` AND `out = DTO`.
- [x] New `TestOutputSchemas_AllAccessorsResolve` resolves every accessor for all 15 tools in CI (catches `mustDeriveSchema` panics before production).
- [x] New `TestOutputSchema_ValidatesPayload` validates fixture payloads for `talos_validate`, `talos_health`, `talos_etcd_snapshot` against their declared schemas (satisfies issue #145 acceptance criterion #3 deterministically, replacing the manual Inspector step).
- [x] All pre-existing tests pass unchanged.

## Review artifacts

Gitignored per project governance. Staff + escalations:
- `staff-reviewer` → escalated to `compatibility`, `architecture`, `provenance`
- `compatibility-reviewer` → approved (after breaking-change commit marker + footer)
- `principal-architect-reviewer` → approved
- `provenance-reviewer` → approved (indirect → direct promotion of already-reachable `github.com/google/jsonschema-go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)