### PR TITLE
chore(skills): scaffold four maintenance skills

### DIFF
--- a/.claude/skills/add-mcp-tool/SKILL.md
+++ b/.claude/skills/add-mcp-tool/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: add-mcp-tool
+description: Scaffold a new Talos MCP tool handler with correct signature, args struct, safety-guard defaults, registration, inventory update, and a test stub. Use when adding a new talos_* tool to internal/tools/.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+argument-hint: <tool-name> [mutating|read]
+---
+
+# Add MCP Tool
+
+Scaffold a new tool handler that conforms to the project's handler signature
+(`func (h *Handlers) HandleXxx(ctx, req, args XxxArgs)`) and safety conventions.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- `$1` — snake_case tool name (required). Must start with `talos_` (e.g. `talos_drain_node`).
+- `$2` — category, one of `mutating` | `read` (default `read`).
+
+Derive `{{ToolName}}` = PascalCase of `$1` with the `talos_` prefix stripped
+(e.g. `talos_drain_node` → `DrainNode`).
+
+If any required argument is missing, ask the user once for the missing value,
+then proceed non-interactively.
+
+## Key Steps
+
+1. **Validate name.** Reject if `$1` does not match `^talos_[a-z][a-z0-9_]*$`.
+2. **Collision check.** Use Glob to confirm `internal/tools/<name>.go` does not
+   exist. If it does, stop and report — do not overwrite.
+3. **Generate handler.** Render `references/handler-template.go.tmpl` with
+   `{{ToolName}}`, `{{tool_name}}`, `{{category}}` substituted. Write to
+   `internal/tools/<name>.go`.
+4. **Apply safety defaults.** For `mutating`, inline `confirm bool` and
+   `nodes []string` on `{{ToolName}}Args`; set `dry_run` / `preserve` /
+   `graceful` defaults from `references/safety-defaults.md`.
+5. **Register the tool.** Grep for `mcp.AddTool` in `internal/tools/` to
+   locate the registration site. Add the new entry in alphabetical order:
+
+   ```go
+   mcp.AddTool(server, &mcp.Tool{Name: "{{tool_name}}"}, h.Handle{{ToolName}})
+   ```
+
+6. **Generate test stub.** Write `internal/tools/<name>_test.go` with one
+   happy-path test and (for `mutating`) a guards-enforcement test.
+7. **Format.** Run `gofmt -w internal/tools/<name>.go internal/tools/<name>_test.go`.
+8. **Update inventory.** Edit the tool-inventory tables in `AGENTS.md` and
+   `README.md`. Preserve alphabetical order.
+
+## Output
+
+On success, print:
+
+```
+Created:   internal/tools/<name>.go
+           internal/tools/<name>_test.go
+Modified:  <registration-file>
+           AGENTS.md  (tool inventory)
+           README.md  (tool inventory)
+Next:      make check
+           invoke staff-reviewer  →  .claude/reviews/<change-id>/review.md
+           commit  →  feat(tools): add <tool_name> handler [review:<change-id>]
+```
+
+On abort (name invalid, collision, template missing): print the reason and
+exit without writes.
+
+## References
+
+- `references/handler-template.go.tmpl` — handler + args struct template patterned on `internal/tools/lifecycle.go`.
+- `references/safety-defaults.md` — per-category default values (mirror of repo-root `CLAUDE.md` § Safety).

--- a/.claude/skills/add-mcp-tool/references/handler-template.go.tmpl
+++ b/.claude/skills/add-mcp-tool/references/handler-template.go.tmpl
@@ -1,0 +1,36 @@
+// TODO: Go template for a new Talos MCP tool handler.
+// Pattern source: internal/tools/lifecycle.go
+//
+// Replace placeholders:
+//   {{ToolName}}      PascalCase handler name (e.g. RebootNode)
+//   {{tool_name}}     snake_case MCP tool id (e.g. talos_reboot_node)
+//   {{Description}}   one-line description
+//
+// Mutating tools MUST include: Confirm bool, Nodes []string, DryRun bool (where applicable).
+
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// {{ToolName}}Args — arguments for the {{tool_name}} tool.
+type {{ToolName}}Args struct {
+	Nodes   []string `json:"nodes"`             // explicit target nodes (required for mutating)
+	Confirm bool     `json:"confirm,omitempty"` // must be true for mutating operations
+	DryRun  bool     `json:"dry_run,omitempty"` // default true for config-mutating tools
+}
+
+// Handle{{ToolName}} — {{Description}}
+func (h *Handlers) Handle{{ToolName}}(
+	ctx context.Context,
+	req *mcp.CallToolRequest,
+	args {{ToolName}}Args,
+) (*mcp.CallToolResult, any, error) {
+	// TODO: validate safety guards (confirm, nodes non-empty) for mutating tools.
+	// TODO: call Talos client.
+	// TODO: return structured result.
+	return nil, nil, nil
+}

--- a/.claude/skills/add-mcp-tool/references/safety-defaults.md
+++ b/.claude/skills/add-mcp-tool/references/safety-defaults.md
@@ -1,0 +1,20 @@
+# Safety Defaults by Tool Category
+
+Source of truth: repo root `CLAUDE.md` § Safety.
+
+| Tool Category / Example      | confirm | dry_run | wait        | preserve | graceful | Notes                                                                 |
+|------------------------------|---------|---------|-------------|----------|----------|-----------------------------------------------------------------------|
+| Read (e.g. `talos_version`)  | n/a     | n/a     | n/a         | n/a      | n/a      | No guards required.                                                   |
+| `talos_reboot`               | true    | n/a     | false (5m)  | n/a      | n/a      | Hits all listed nodes simultaneously — specify one node at a time.    |
+| `talos_upgrade`              | true    | n/a     | n/a         | true     | n/a      | `preserve=true` keeps EPHEMERAL; differs from talosctl default false. |
+| `talos_rollback`             | true    | n/a     | n/a         | n/a      | n/a      | Requires explicit nodes.                                              |
+| `talos_reset`                | true    | n/a     | n/a         | n/a      | true     | `graceful=true` drains workloads, leaves etcd; false = unresponsive.  |
+| `talos_patch_config`         | true    | true    | n/a         | n/a      | n/a      | `dry_run=true` by default; set false + confirm=true to apply.         |
+| `talos_apply_config`         | true    | true    | n/a         | n/a      | n/a      | Exactly one node; max 1 MiB YAML/JSON; replaces entire machine config.|
+
+## Rules
+
+- Mutating tools MUST require `confirm=true` and explicit `nodes`.
+- Config-mutating tools MUST default `dry_run=true`.
+- Never wipe secrets via context — `talos_apply_config` takes a local file path only.
+- `system_labels_to_wipe` empty on `talos_reset` = full disk wipe; document loudly.

--- a/.claude/skills/guard-mutating-tool/SKILL.md
+++ b/.claude/skills/guard-mutating-tool/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: guard-mutating-tool
+description: Verify that a diff touching mutating Talos tools (reboot, upgrade, rollback, reset, patch_config, apply_config) preserves all required guards — confirm=true, explicit nodes, correct dry_run/preserve/graceful defaults. Run before requesting staff-reviewer.
+allowed-tools: Read, Grep, Glob, Bash
+argument-hint: "[--base <ref>]"
+---
+
+# Guard Mutating Tool
+
+Scan the current diff against the `CLAUDE.md` § Safety matrix (cached in
+`references/guard-matrix.md`) and emit a structured report the
+`staff-reviewer` agent can consume directly.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- `--base <ref>` — base ref for the diff. Defaults to `origin/main`.
+
+Validate the base ref:
+
+```bash
+git rev-parse --verify "${BASE:-origin/main}" >/dev/null \
+  || abort "Unknown base ref: $BASE"
+```
+
+## Key Steps
+
+1. **List changed mutating-tool files.**
+   ```bash
+   git diff --name-only "${BASE:-origin/main}"...HEAD -- 'internal/tools/*.go'
+   ```
+   Filter by basename to one of: `lifecycle`, `files`, `patch_blocklist`
+   (files that implement `reboot`, `upgrade`, `rollback`, `reset`,
+   `patch_config`, `apply_config`). Exit early with verdict `GO` if the
+   filtered list is empty.
+
+2. **Load the guard matrix.** Read `references/guard-matrix.md`. Its
+   `required_args` and `default_values` columns are the ground truth.
+
+3. **Scan each file for guard presence.** For every matched file:
+   ```bash
+   git diff "${BASE:-origin/main}"...HEAD -U3 -- <file> \
+     | grep -nE 'confirm|nodes|dry_run|preserve|graceful|wait'
+   ```
+   Cross-reference the hunks against the matrix row for the tool.
+
+4. **Classify each guard.** Flag a regression when:
+   - a required-arg check was removed (deletion of `if !confirm` / `len(nodes)==0`),
+   - a default literal changed (e.g. `dry_run: true` → `dry_run: false`),
+   - a new control-flow path reaches the mutating gRPC call without passing
+     through the guard check.
+
+5. **Emit the report.** Use the exact template below.
+
+## Report Format
+
+```
+## Guard Audit — <change-id>
+
+| tool              | required_args_ok | defaults_ok | evidence                    | verdict |
+|-------------------|------------------|-------------|-----------------------------|---------|
+| talos_reboot      | yes/no           | yes/no      | <file:line> `<quoted code>` | pass/fail |
+| talos_upgrade     | ...              | ...         | ...                         | ...     |
+| talos_rollback    | ...              | ...         | ...                         | ...     |
+| talos_reset       | ...              | ...         | ...                         | ...     |
+| talos_patch_config| ...              | ...         | ...                         | ...     |
+| talos_apply_config| ...              | ...         | ...                         | ...     |
+
+## Findings
+- **<tool>.<guard>** — <pass|regress|missing>
+  Evidence: <file:line> `<quoted code>`
+  Validation: re-run `grep -nE '<pattern>' <file>` — guard still present.
+
+## Verdict
+<approved | escalate: guards regressed>
+```
+
+Omit rows for tools whose file was not touched.
+
+## References
+
+- `references/guard-matrix.md` — guard matrix mirrored verbatim from repo-root `CLAUDE.md` § Safety.

--- a/.claude/skills/guard-mutating-tool/references/guard-matrix.md
+++ b/.claude/skills/guard-mutating-tool/references/guard-matrix.md
@@ -1,0 +1,25 @@
+# Guard Matrix
+
+Authoritative guard requirements extracted verbatim from `CLAUDE.md` § Safety.
+Mutating tools require explicit guards — missing any of these will error or
+cause irreversible cluster damage.
+
+## Source (CLAUDE.md § Safety)
+
+- `talos_reboot`, `talos_upgrade`, `talos_rollback`, `talos_reset` all require `confirm=true` and explicit `nodes`.
+- `talos_reboot` hits **all listed nodes simultaneously** — specify one at a time to avoid a full outage. Use `wait=true` to block until complete (default timeout `5m`).
+- `talos_upgrade` `preserve` defaults to `true` (keep EPHEMERAL partition) — differs from `talosctl` default of `false`.
+- `talos_reset` `graceful` defaults to `true` (drain workloads, leave etcd). Set `false` only on unresponsive nodes. `system_labels_to_wipe` empty = full disk wipe.
+- `talos_patch_config` defaults `dry_run=true`; pass `dry_run=false` + `confirm=true` to apply.
+- `talos_apply_config` takes `config_file` (absolute local path to YAML/JSON, max 1 MiB — secrets never enter context). Defaults `dry_run=true`, requires exactly one node. Replaces entire machine config — prefer `talos_patch_config` for targeted changes.
+
+## Matrix
+
+| tool_name            | required_args                          | default_values                                               | notes |
+|----------------------|----------------------------------------|--------------------------------------------------------------|-------|
+| `talos_reboot`       | `confirm=true`, `nodes`                | `wait=false` (timeout `5m` when `wait=true`)                 | Hits all listed nodes simultaneously — specify one at a time to avoid full outage. |
+| `talos_upgrade`      | `confirm=true`, `nodes`                | `preserve=true`                                              | `preserve` default differs from `talosctl` default (`false`); keeps EPHEMERAL partition. |
+| `talos_rollback`     | `confirm=true`, `nodes`                | —                                                            | Requires explicit confirm + nodes. |
+| `talos_reset`        | `confirm=true`, `nodes`                | `graceful=true`, `system_labels_to_wipe=[]`                  | Set `graceful=false` only on unresponsive nodes. Empty `system_labels_to_wipe` = full disk wipe. |
+| `talos_patch_config` | (to apply) `dry_run=false`, `confirm=true` | `dry_run=true`                                           | Safe-by-default: dry run unless explicitly overridden. |
+| `talos_apply_config` | `config_file` (absolute path, YAML/JSON, ≤1 MiB), exactly one node | `dry_run=true`                             | Replaces entire machine config; prefer `talos_patch_config` for targeted changes. Secrets never enter context. |

--- a/.claude/skills/refresh-tool-inventory/SKILL.md
+++ b/.claude/skills/refresh-tool-inventory/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: refresh-tool-inventory
+description: Extract the current tool/prompt/resource inventory from internal/{tools,prompts,resources} and update the inventory tables in AGENTS.md and README.md. Defaults to dry-run. Use when handlers are added, renamed, or removed.
+allowed-tools: Read, Edit, Grep, Glob, Bash
+argument-hint: "[--apply]"
+---
+
+# Refresh Tool Inventory
+
+Regenerate the tool/prompt/resource tables in `AGENTS.md` and `README.md`
+from the source of truth (the Go packages in `internal/`).
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- `--apply` — write changes. Default is dry-run (print diff only).
+
+## Key Steps
+
+1. **Enumerate registered handlers.** Grep every registration call:
+   ```bash
+   grep -nE 'mcp\.(AddTool|AddPrompt|AddResource)' \
+     internal/tools internal/prompts internal/resources -r
+   ```
+   Capture `kind` (tool/prompt/resource), `name`, `handler`, `file:line`.
+
+2. **Extract description.** For each handler, Read the surrounding tool
+   definition to pull `Description:` / `Title:` fields. If absent, record
+   description as `<missing>` and flag in the report.
+
+3. **Compute diff.** Locate the inventory tables in `AGENTS.md` and
+   `README.md` using these sentinel markers (REQUIRED — abort if missing):
+
+   ```
+   <!-- inventory:tools:start -->  ...  <!-- inventory:tools:end -->
+   <!-- inventory:prompts:start --> ...  <!-- inventory:prompts:end -->
+   <!-- inventory:resources:start --> ...  <!-- inventory:resources:end -->
+   ```
+
+   If any sentinel is missing, abort with:
+   `ERROR: sentinel <name> missing in <file> — add markers before re-running.`
+   Never guess table boundaries.
+
+4. **Emit preview.** Print the unified diff between the current tables and
+   the regenerated tables.
+
+5. **Apply (only if `--apply`).** Use Edit to replace the content between
+   each matching sentinel pair. Leave everything outside the sentinels
+   untouched.
+
+## Output Format
+
+```
+Inventory diff (tools | prompts | resources):
+  Added:    <name> (<kind>) — <file:line>
+  Removed:  <name> (<kind>)
+  Renamed:  <old> → <new>
+  Changed:  <name> — description updated
+
+Files that would be updated: AGENTS.md, README.md
+Mode: dry-run | apply
+```
+
+On dry-run, print the diff and exit. On `--apply`, also write and print the
+final file paths.
+
+## Notes
+
+Prefer promoting the extraction step to a deterministic shell or Go script
+under `scripts/` once the format stabilises — this skill should then shrink
+to "invoke the script, preview, apply" (per the project's deterministic
+hierarchy rule).

--- a/.claude/skills/release-preflight/SKILL.md
+++ b/.claude/skills/release-preflight/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: release-preflight
+description: Pre-tag validation for talos-mcp releases — resolve release range, scan conventional commit prefixes, derive expected bump, run goreleaser check, verify release.yml npm OIDC invariants (node-version "24", no registry-url, --provenance). Run before pushing a v* tag.
+allowed-tools: Read, Grep, Bash
+argument-hint: "[--from <prev-tag>]"
+---
+
+# Release Preflight
+
+Validate release readiness before a `v*` tag is pushed. Fails closed — any
+blocker yields `NO-GO` and the skill never instructs the user to push on
+`NO-GO`.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- `--from <tag>` — base tag. If absent, resolve via:
+  ```bash
+  git describe --tags --abbrev=0 --match 'v*'
+  ```
+  If no prior `v*` tag exists and `--from` was not supplied, abort:
+  `NO-GO: no prior v* tag and --from not supplied.`
+
+Bind the resolved value as `PREV`.
+
+## Key Steps
+
+1. **Resolve the release range.** Scan commits that touched server paths
+   (release triggers per `CLAUDE.md` § Release):
+   ```bash
+   git log "$PREV"..HEAD --pretty=format:'%s%n%b' \
+     -- cmd internal go.mod go.sum Makefile
+   ```
+   If the filtered result is empty, abort:
+   `NO-GO: range contains only docs/ci/chore changes — do not tag.`
+
+2. **Derive expected bump.** Apply this mapping to the filtered commit
+   subjects, take the highest bump seen:
+
+   | Prefix                                     | Bump   |
+   |--------------------------------------------|--------|
+   | `feat!:` / `BREAKING CHANGE:` in body      | major  |
+   | `feat:`                                    | minor  |
+   | `fix:`                                     | patch  |
+   | `docs:` / `ci:` / `chore:` / `build:`      | none   |
+
+   Confirm with the user via `AskUserQuestion` (header `Bump`): computed
+   bump as the recommended option, plus alternatives and `Cancel`.
+   `Cancel` ⇒ `NO-GO`.
+
+3. **Goreleaser.**
+   ```bash
+   command -v goreleaser >/dev/null || blocker "goreleaser not installed"
+   goreleaser check                 || blocker "goreleaser check failed"
+   ```
+
+4. **release.yml invariants.** Verify `.github/workflows/release.yml`
+   exists (blocker if not), then apply the checks from
+   `references/release-checks.md`:
+   - `node-version: "24"` (not 22, not 20)
+   - no `registry-url:` set on `actions/setup-node`
+   - `--provenance` present on every `npm publish` call
+   Each mismatch is a blocker; continue running remaining checks to build
+   a complete report.
+
+5. **Trusted Publisher reminder.** If the range is the first release of
+   the npm package (no prior `v*` tag), prompt via `AskUserQuestion`:
+   `"Trusted Publisher configured at https://www.npmjs.com/package/<pkg>/access?"` —
+   `No` ⇒ `NO-GO`.
+
+6. **Emit the report** (exact template below). On any blocker, `Verdict:
+   NO-GO`.
+
+## Report Format
+
+```
+## Release Preflight — <PREV>..HEAD
+
+Verdict: GO | NO-GO
+
+| # | Check                        | Status | Evidence                          |
+|---|------------------------------|--------|-----------------------------------|
+| 1 | node-version "24"            | pass   | release.yml:<line> matches        |
+| 2 | no registry-url              | pass   | 0 matches in release.yml          |
+| 3 | --provenance on publish      | pass   | release.yml:<line>                |
+| 4 | commit-prefix scan           | pass   | bump=<patch|minor|major>          |
+| 5 | goreleaser check             | pass   | exit 0                            |
+| 6 | trusted publisher (if first) | pass   | user-confirmed                    |
+
+Expected bump: <bump>   Intended tag: v<x.y.z>
+
+Blockers: <empty on GO; otherwise bulleted list with fix hints>
+```
+
+## References
+
+- `references/release-checks.md` — full catalogue expanded from `.claude/rules/release-workflow.md` with concrete verification commands.

--- a/.claude/skills/release-preflight/references/release-checks.md
+++ b/.claude/skills/release-preflight/references/release-checks.md
@@ -1,0 +1,52 @@
+# Release Checks
+
+Catalogue of pre-tag validation items for talos-mcp-server. Each entry: check name, how to verify, expected result. Derived from `.claude/rules/release-workflow.md` and `CLAUDE.md § Release`.
+
+## release.yml Configuration Checks
+
+1. **node-version pin = "24"**
+   - How: `grep -n 'node-version' .github/workflows/release.yml`
+   - Expected: every `actions/setup-node` step specifies `node-version: "24"`. Node 22 ships npm 10.x which cannot self-upgrade to npm 11 (`MODULE_NOT_FOUND`). Node 24 ships npm 11 natively.
+
+2. **No `registry-url` in `actions/setup-node`**
+   - How: `grep -n 'registry-url' .github/workflows/release.yml`
+   - Expected: zero matches. `registry-url` writes `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}` placeholder, which blocks the OIDC token exchange and returns 404.
+
+3. **`--provenance` on every `npm publish`**
+   - How: `grep -nE 'npm publish' .github/workflows/release.yml`
+   - Expected: every `npm publish` invocation includes `--provenance`. Provenance is not auto-generated; the flag is harmless under OIDC and required under token auth.
+
+4. **Trusted Publisher configured on npmjs.com**
+   - How: Manual verification at `https://www.npmjs.com/package/<name>/access`.
+   - Expected: Trusted Publisher entry exists for this GitHub repo + workflow. One-time per package.
+
+## Release-Range Conventional Commit Scan
+
+5. **Commit prefix scan for bump derivation**
+   - How: `git log <prev-tag>..HEAD --pretty=format:'%s'`
+   - Expected: each subject begins with a recognised conventional prefix. Map to bump:
+
+     | Prefix                                  | Server-path bump |
+     |-----------------------------------------|------------------|
+     | `fix:`                                  | patch            |
+     | `feat:`                                 | minor            |
+     | `feat!:` / body contains `BREAKING CHANGE:` | major        |
+     | `docs:` / `ci:` / `chore:`              | no release       |
+
+     Only server paths trigger a release — doc/CI/chore-only ranges must not be tagged.
+
+6. **Bump consistency**
+   - How: Take the highest bump implied by the scan.
+   - Expected: matches the tag the user intends to push. Mismatch = abort.
+
+## Build-System Checks
+
+7. **`goreleaser check`**
+   - How: `goreleaser check`
+   - Expected: exit 0, no warnings. Validates `.goreleaser.yaml` syntax and config before a tag push triggers a real release.
+
+## Final Gate
+
+8. **Go/No-Go report**
+   - How: Aggregate results of checks 1–7.
+   - Expected: all checks pass → GO. Any failure → NO-GO with the offending check id(s) listed.


### PR DESCRIPTION
## What does this PR do?

**Change ID:** scaffold-maintenance-skills

Adds four Claude Code maintenance skills under `.claude/skills/`, scaffolded from a `/suggest-skills` audit of the repo:

- **add-mcp-tool** — scaffold new `talos_*` tool handlers (signature, args, safety defaults, registration, test stub, inventory update)
- **guard-mutating-tool** — verify PR diffs preserve mutating-tool safety guards per `CLAUDE.md § Safety`
- **refresh-tool-inventory** — regenerate tool/prompt/resource inventory tables from `internal/` sources (dry-run default, `--apply` to write)
- **release-preflight** — pre-tag validation (conventional-commit scan, `goreleaser check`, npm OIDC invariants, Trusted Publisher reminder)

All four include concrete commands, literal output templates, fail-closed error handling, and reference files where domain detail would bloat the SKILL.md. Skills were reviewed twice via `skill-quality:review-skill` — final grades **B/A/B/A** (89.75 / 91.5 / 87 / 93).

## Checklist

- [x] `make check` passes locally (fmt + vet + lint + test) — exit 0, coverage 38.6%
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) — `chore(skills): ... [review:scaffold-maintenance-skills]`
- [x] New/changed tools include tests — N/A (no Go code; skill artifacts)
- [x] Documentation updated if applicable — N/A (skills are self-contained under `.claude/skills/`)

## Notes

- No source code, go.mod, or API-surface changes.
- Review artifact at `.claude/reviews/scaffold-maintenance-skills/review.md` (gitignored local gate per repo convention).
- Residual Medium/Low polish items (Bash-scoping, rename-heuristics, worked NO-GO example) are tracked as follow-ups — not blockers for landing the skeletons.
