### PR TITLE
feat(tools): emit progress notifications for talos_reset

### DIFF
--- a/internal/tools/lifecycle.go
+++ b/internal/tools/lifecycle.go
@@ -778,7 +778,7 @@ type ResetArgs struct {
 }
 
 // HandleReset implements the talos_reset tool.
-func (h *Handlers) HandleReset(ctx context.Context, _ *mcp.CallToolRequest, args ResetArgs) (*mcp.CallToolResult, any, error) {
+func (h *Handlers) HandleReset(ctx context.Context, req *mcp.CallToolRequest, args ResetArgs) (*mcp.CallToolResult, any, error) {
 	h.auditLog("talos_reset", args, args.Nodes)
 
 	if !args.Confirm {
@@ -803,18 +803,22 @@ func (h *Handlers) HandleReset(ctx context.Context, _ *mcp.CallToolRequest, args
 		})
 	}
 
-	req := &machineapi.ResetRequest{
+	resetReq := &machineapi.ResetRequest{
 		Graceful:               resolveGraceful(args.Graceful),
 		Reboot:                 args.Reboot,
 		SystemPartitionsToWipe: partitions,
 		Mode:                   machineapi.ResetRequest_SYSTEM_DISK,
 	}
 
-	resp, err := h.Client.ResetGenericWithResponse(nodeCtx, req)
+	notifyProgress(ctx, req, "Initiating reset", 1, 2)
+
+	resp, err := h.Client.ResetGenericWithResponse(nodeCtx, resetReq)
 	if err != nil {
 		h.mcpLogError("talos_reset", err)
 		return nil, nil, fmt.Errorf("reset: %w", err)
 	}
+
+	notifyProgress(ctx, req, "Reset initiated", 2, 2)
 
 	return jsonResult(resp)
 }

--- a/internal/tools/progress_test.go
+++ b/internal/tools/progress_test.go
@@ -1,0 +1,102 @@
+package tools
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// resetStubClient embeds mockClient (whose methods panic) and overrides only
+// ResetGenericWithResponse so HandleReset can complete end-to-end in tests.
+type resetStubClient struct {
+	mockClient
+}
+
+func (r *resetStubClient) ResetGenericWithResponse(_ context.Context, _ *machineapi.ResetRequest) (*machineapi.ResetResponse, error) {
+	return &machineapi.ResetResponse{}, nil
+}
+
+// TestHandleReset_EmitsProgress verifies that talos_reset emits the expected
+// pair of MCP progress notifications when the caller supplies a progressToken.
+// The test drives HandleReset end-to-end through the go-sdk in-memory transport
+// so the assertion exercises the real Session.NotifyProgress path.
+func TestHandleReset_EmitsProgress(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	h := &Handlers{Client: &resetStubClient{}}
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "talos-mcp-test"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "talos_reset"}, h.HandleReset)
+
+	var (
+		mu       sync.Mutex
+		messages []string
+	)
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, &mcp.ClientOptions{
+		ProgressNotificationHandler: func(_ context.Context, req *mcp.ProgressNotificationClientRequest) {
+			if req == nil || req.Params == nil {
+				return
+			}
+			mu.Lock()
+			messages = append(messages, req.Params.Message)
+			mu.Unlock()
+		},
+	})
+
+	serverT, clientT := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverT, nil)
+	if err != nil {
+		t.Fatalf("server.Connect: %v", err)
+	}
+	defer func() { _ = serverSession.Close() }()
+
+	clientSession, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	defer func() { _ = clientSession.Close() }()
+
+	params := &mcp.CallToolParams{
+		Name: "talos_reset",
+		Arguments: ResetArgs{
+			Nodes:   []string{"test-node"},
+			Confirm: true,
+		},
+	}
+	params.SetProgressToken("reset-progress-1")
+
+	if _, err := clientSession.CallTool(ctx, params); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	// Progress notifications are asynchronous relative to the tool response;
+	// give the transport a brief grace period to deliver them.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		n := len(messages)
+		mu.Unlock()
+		if n >= 2 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(messages) < 2 {
+		t.Fatalf("expected >=2 progress notifications, got %d: %v", len(messages), messages)
+	}
+	if messages[0] != "Initiating reset" {
+		t.Errorf("first message = %q, want %q", messages[0], "Initiating reset")
+	}
+	if messages[1] != "Reset initiated" {
+		t.Errorf("second message = %q, want %q", messages[1], "Reset initiated")
+	}
+}


### PR DESCRIPTION
## Summary

- Wire `HandleReset` to the existing `notifyProgress` helper so `talos_reset` emits `notifications/progress` events, matching the pattern already in `HandleReboot`, `HandleUpgrade`, `HandleRollback`, and `HandleApplyConfig`.
- Emits `"Initiating reset"` (1/2) before the gRPC call and `"Reset initiated"` (2/2) after success. The helper remains a no-op when the caller omits a `progressToken` or `req` is `nil`, so callers are unaffected.
- Adds `TestHandleReset_EmitsProgress` which drives `HandleReset` end-to-end through the go-sdk in-memory transport and asserts the expected message sequence on the client's `ProgressNotificationHandler`.

Closes #146.

Progress is sent via the per-call `req.Session`, which is request-scoped — safe in HTTP mode even though the shared logger is intentionally skipped there (`cmd/talos-mcp/main.go:151`). Per-phase Talos lifecycle streaming and additional handlers are explicitly out of scope: the other long-running handlers already emit progress, and the Talos gRPC API does not expose a lifecycle event stream (polling is canonical).

## Test plan

- [x] `make check` green (fmt + vet + lint + test + coverage)
- [x] `TestHandleReset_EmitsProgress` passes — asserts two progress messages arrive in order
- [x] `TestHandleReset_Guards` still passes (`req=nil` path remains safe)
- [ ] Manual smoke (optional): run `talos-mcp` under the MCP inspector and invoke `talos_reset` against a scratch node; observe the two progress events in the inspector notification stream

Reviewed by staff-reviewer (`.claude/reviews/issue-146-progress-reset/review.md`, status: approved, 0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)