### PR TITLE
feat(completions): add MCP completion handler for prompts and resource templates

### DIFF
--- a/cmd/talos-mcp/main.go
+++ b/cmd/talos-mcp/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/Nosmoht/talos-mcp-server/internal/completions"
 	"github.com/Nosmoht/talos-mcp-server/internal/prompts"
 	"github.com/Nosmoht/talos-mcp-server/internal/resources"
 	"github.com/Nosmoht/talos-mcp-server/internal/talos"
@@ -146,6 +147,7 @@ func main() {
 			"All tools accept an optional 'nodes' field to target specific node IPs; " +
 			"omit it to use the active context from talosconfig. " +
 			"Destructive tools (talos_reboot, talos_upgrade) require confirm=true and explicit nodes.",
+		CompletionHandler: completions.NewHandler(allowedNodes),
 	}
 
 	if httpAddr == "" {

--- a/internal/completions/candidates.go
+++ b/internal/completions/candidates.go
@@ -1,0 +1,20 @@
+package completions
+
+// knownServices is the curated list of Talos system services that appear in
+// talos_services on a healthy node. Source: talosctl service list output on
+// Talos v1.9. Keep sorted for deterministic completion order.
+var knownServices = []string{
+	"apid", "containerd", "cri", "etcd", "kubelet",
+	"machined", "trustd", "udevd",
+}
+
+// applyModes mirrors the enum documented in internal/prompts/apply.go.
+var applyModes = []string{"auto", "no_reboot", "reboot", "staged", "try"}
+
+// commonNamespaces lists the COSI namespaces that appear in a default Talos
+// cluster. Less-common namespaces still work at tool-call time; they just
+// won't appear in autosuggest.
+var commonNamespaces = []string{
+	"cluster", "config", "cri", "files", "hardware",
+	"k8s", "network", "runtime", "time", "v1alpha1",
+}

--- a/internal/completions/completions.go
+++ b/internal/completions/completions.go
@@ -1,0 +1,118 @@
+// Package completions implements the MCP completion/complete handler for
+// talos-mcp. It returns argument suggestions for registered prompts and
+// resource templates; it never performs cluster I/O.
+//
+// CompleteParams.Context.Arguments (previously-resolved template variables)
+// is intentionally ignored: all candidate sources are static tables or the
+// in-memory node allowlist, neither of which depends on prior selections.
+// When dynamic discovery is added, thread Context.Arguments through to
+// scope the result.
+package completions
+
+import (
+	"context"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/Nosmoht/talos-mcp-server/internal/talos"
+)
+
+// NewHandler returns a CompletionHandler bound to allowedNodes. The returned
+// handler is safe for concurrent use: it reads immutable static tables and
+// only calls NodeAllowlist.Exact, which returns a fresh slice per call.
+func NewHandler(allowedNodes *talos.NodeAllowlist) func(context.Context, *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+	return func(_ context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+		ref := req.Params.Ref
+		if ref == nil {
+			return emptyResult(), nil
+		}
+		name := req.Params.Argument.Name
+		partial := req.Params.Argument.Value
+
+		var cands []string
+		switch ref.Type {
+		case "ref/prompt":
+			cands = forPrompt(ref.Name, name, allowedNodes)
+		case "ref/resource":
+			cands = forResource(ref.URI, name, allowedNodes)
+		}
+		values := filterPrefix(cands, partial)
+		if values == nil {
+			return emptyResult(), nil
+		}
+		return &mcp.CompleteResult{
+			Completion: mcp.CompletionResultDetails{Values: values},
+		}, nil
+	}
+}
+
+// emptyResult returns a result whose Values is a non-nil empty slice. The
+// MCP wire format requires "values" to be an array; a nil []string would
+// marshal to null and break spec-compliant clients.
+func emptyResult() *mcp.CompleteResult {
+	return &mcp.CompleteResult{
+		Completion: mcp.CompletionResultDetails{Values: []string{}},
+	}
+}
+
+// forPrompt dispatches on (promptName, argName). Prompt name is part of the
+// key because the same argument label can mean different things in a
+// hypothetical future prompt.
+func forPrompt(promptName, arg string, nodes *talos.NodeAllowlist) []string {
+	switch promptName {
+	case "diagnose-node", "investigate-etcd":
+		if arg == "node" {
+			return nodes.Exact()
+		}
+	case "debug-service":
+		switch arg {
+		case "node":
+			return nodes.Exact()
+		case "service":
+			return knownServices
+		}
+	case "pre-upgrade-checklist":
+		if arg == "nodes" {
+			return nodes.Exact()
+		}
+	case "apply-config":
+		switch arg {
+		case "node":
+			return nodes.Exact()
+		case "mode":
+			return applyModes
+		}
+	}
+	return nil
+}
+
+// forResource dispatches on (template URI prefix, argName). The "talos://"
+// prefix check scopes this resolver to the templates registered in
+// internal/resources/resources.go.
+func forResource(uri, arg string, nodes *talos.NodeAllowlist) []string {
+	if !strings.HasPrefix(uri, "talos://") {
+		return nil
+	}
+	switch arg {
+	case "node":
+		return nodes.Exact()
+	case "namespace":
+		return commonNamespaces
+	}
+	return nil
+}
+
+func filterPrefix(cands []string, partial string) []string {
+	if partial == "" {
+		return cands
+	}
+	p := strings.ToLower(partial)
+	out := make([]string, 0, len(cands))
+	for _, c := range cands {
+		if strings.HasPrefix(strings.ToLower(c), p) {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/internal/completions/completions_test.go
+++ b/internal/completions/completions_test.go
@@ -1,0 +1,232 @@
+package completions
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/Nosmoht/talos-mcp-server/internal/talos"
+)
+
+func mustAllowlist(t *testing.T, csv string) *talos.NodeAllowlist {
+	t.Helper()
+	a, err := talos.ParseNodeAllowlist(csv)
+	if err != nil {
+		t.Fatalf("ParseNodeAllowlist(%q): %v", csv, err)
+	}
+	return a
+}
+
+func callHandle(
+	t *testing.T,
+	allow *talos.NodeAllowlist,
+	ref *mcp.CompleteReference,
+	argName, partial string,
+	ctxArgs map[string]string,
+) []string {
+	t.Helper()
+	h := NewHandler(allow)
+	var cctx *mcp.CompleteContext
+	if ctxArgs != nil {
+		cctx = &mcp.CompleteContext{Arguments: ctxArgs}
+	}
+	res, err := h(context.Background(), &mcp.CompleteRequest{
+		Params: &mcp.CompleteParams{
+			Ref:      ref,
+			Argument: mcp.CompleteParamsArgument{Name: argName, Value: partial},
+			Context:  cctx,
+		},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatalf("handler returned nil result")
+	}
+	return res.Completion.Values
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPromptCompletion(t *testing.T) {
+	allow := mustAllowlist(t, "192.0.2.11,192.0.2.10")
+
+	tests := []struct {
+		name    string
+		prompt  string
+		arg     string
+		partial string
+		want    []string
+	}{
+		{
+			name:   "diagnose-node node returns allowlist",
+			prompt: "diagnose-node",
+			arg:    "node",
+			want:   []string{"192.0.2.10", "192.0.2.11"},
+		},
+		{
+			name:   "investigate-etcd node returns allowlist",
+			prompt: "investigate-etcd",
+			arg:    "node",
+			want:   []string{"192.0.2.10", "192.0.2.11"},
+		},
+		{
+			name:   "pre-upgrade-checklist nodes returns allowlist",
+			prompt: "pre-upgrade-checklist",
+			arg:    "nodes",
+			want:   []string{"192.0.2.10", "192.0.2.11"},
+		},
+		{
+			name:    "debug-service node with partial filters allowlist",
+			prompt:  "debug-service",
+			arg:     "node",
+			partial: "192.0.2.1",
+			want:    []string{"192.0.2.10", "192.0.2.11"},
+		},
+		{
+			name:   "apply-config mode returns exact modes",
+			prompt: "apply-config",
+			arg:    "mode",
+			want:   []string{"auto", "no_reboot", "reboot", "staged", "try"},
+		},
+		{
+			name:    "unknown prompt returns empty",
+			prompt:  "not-a-prompt",
+			arg:     "node",
+			partial: "",
+			want:    []string{},
+		},
+		{
+			name:    "known prompt unknown arg returns empty",
+			prompt:  "diagnose-node",
+			arg:     "not-a-field",
+			partial: "",
+			want:    []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := callHandle(t, allow, &mcp.CompleteReference{Type: "ref/prompt", Name: tt.prompt}, tt.arg, tt.partial, nil)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("values = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPromptServiceCompletion(t *testing.T) {
+	allow := mustAllowlist(t, "")
+	got := callHandle(t, allow, &mcp.CompleteReference{Type: "ref/prompt", Name: "debug-service"}, "service", "", nil)
+	if !contains(got, "kubelet") || !contains(got, "etcd") {
+		t.Errorf("expected kubelet and etcd in %#v", got)
+	}
+	// sorted deterministic check
+	want := []string{"apid", "containerd", "cri", "etcd", "kubelet", "machined", "trustd", "udevd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("service list = %#v, want %#v", got, want)
+	}
+}
+
+func TestPromptServiceCaseInsensitivePrefix(t *testing.T) {
+	allow := mustAllowlist(t, "")
+	got := callHandle(t, allow, &mcp.CompleteReference{Type: "ref/prompt", Name: "debug-service"}, "service", "KU", nil)
+	if !reflect.DeepEqual(got, []string{"kubelet"}) {
+		t.Errorf("case-insensitive prefix filter returned %#v, want [kubelet]", got)
+	}
+}
+
+func TestResourceCompletion(t *testing.T) {
+	allow := mustAllowlist(t, "192.0.2.10,192.0.2.11")
+	const talosTpl = "talos://{node}/resource/{namespace}/{type}"
+
+	t.Run("namespace returns common namespaces", func(t *testing.T) {
+		got := callHandle(t, allow, &mcp.CompleteReference{Type: "ref/resource", URI: talosTpl}, "namespace", "", nil)
+		if !contains(got, "runtime") {
+			t.Errorf("expected runtime in %#v", got)
+		}
+	})
+
+	t.Run("node with partial filters allowlist", func(t *testing.T) {
+		got := callHandle(t, allow, &mcp.CompleteReference{Type: "ref/resource", URI: talosTpl}, "node", "192.0.2", nil)
+		want := []string{"192.0.2.10", "192.0.2.11"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("node values = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("type deferred returns empty", func(t *testing.T) {
+		got := callHandle(t, allow, &mcp.CompleteReference{Type: "ref/resource", URI: talosTpl}, "type", "", nil)
+		if len(got) != 0 {
+			t.Errorf("expected empty values for type arg, got %#v", got)
+		}
+	})
+
+	t.Run("non-talos URI returns empty", func(t *testing.T) {
+		got := callHandle(t, allow, &mcp.CompleteReference{Type: "ref/resource", URI: "file:///etc/hosts"}, "namespace", "", nil)
+		if len(got) != 0 {
+			t.Errorf("expected empty values for non-talos URI, got %#v", got)
+		}
+	})
+}
+
+func TestUnknownRefType(t *testing.T) {
+	// Bypass SDK unmarshal validation by constructing the ref directly.
+	got := callHandle(t, nil, &mcp.CompleteReference{Type: "ref/tool", Name: "whatever"}, "arg", "", nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty for unknown ref type, got %#v", got)
+	}
+}
+
+func TestNilAllowlistNoPanic(t *testing.T) {
+	got := callHandle(t, nil, &mcp.CompleteReference{Type: "ref/prompt", Name: "diagnose-node"}, "node", "", nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty values for nil allowlist, got %#v", got)
+	}
+}
+
+func TestCIDROnlyAllowlistReturnsEmpty(t *testing.T) {
+	allow := mustAllowlist(t, "192.0.2.0/24")
+	got := callHandle(t, allow, &mcp.CompleteReference{Type: "ref/prompt", Name: "diagnose-node"}, "node", "", nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty values for CIDR-only allowlist, got %#v", got)
+	}
+}
+
+func TestContextArgumentsIgnoredButAccepted(t *testing.T) {
+	// Regression guard: the handler must accept requests with Context.Arguments
+	// populated (MCP clients send this for later template variables) and
+	// continue to return candidates without consulting it. When dynamic
+	// discovery is added, this test will need to be updated.
+	allow := mustAllowlist(t, "192.0.2.10")
+	ctxArgs := map[string]string{"node": "192.0.2.99"} // unrelated to result
+	got := callHandle(t, allow, &mcp.CompleteReference{Type: "ref/resource", URI: "talos://{node}/resource/{namespace}/{type}"}, "namespace", "run", ctxArgs)
+	if !contains(got, "runtime") {
+		t.Errorf("expected runtime in %#v despite Context.Arguments", got)
+	}
+}
+
+func TestNilRefReturnsEmpty(t *testing.T) {
+	h := NewHandler(nil)
+	res, err := h(context.Background(), &mcp.CompleteRequest{
+		Params: &mcp.CompleteParams{
+			Ref:      nil,
+			Argument: mcp.CompleteParamsArgument{Name: "x", Value: ""},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil || len(res.Completion.Values) != 0 {
+		t.Errorf("expected empty result for nil ref, got %#v", res)
+	}
+}

--- a/internal/talos/nodes.go
+++ b/internal/talos/nodes.go
@@ -3,6 +3,7 @@ package talos
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 )
 
@@ -86,6 +87,22 @@ func (a *NodeAllowlist) Len() int {
 		return 0
 	}
 	return len(a.exact) + len(a.cidrs)
+}
+
+// Exact returns a sorted copy of the exact-match allowlist entries (normalized
+// IPs and lowercased hostnames). CIDR ranges are omitted — they cannot be
+// enumerated as discrete completion candidates. Returns nil when the allowlist
+// is disabled.
+func (a *NodeAllowlist) Exact() []string {
+	if a == nil {
+		return nil
+	}
+	out := make([]string, 0, len(a.exact))
+	for k := range a.exact {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // CheckNodes returns the first error from CheckNode across all nodes, or nil

--- a/internal/talos/nodes_exact_test.go
+++ b/internal/talos/nodes_exact_test.go
@@ -1,0 +1,59 @@
+package talos
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNodeAllowlist_Exact(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowlist string
+		want      []string
+	}{
+		{
+			name:      "nil allowlist returns nil",
+			allowlist: "",
+			want:      nil,
+		},
+		{
+			name:      "CIDR-only allowlist returns empty non-nil",
+			allowlist: "192.0.2.0/24",
+			want:      []string{},
+		},
+		{
+			name:      "IPs only returns sorted list",
+			allowlist: "192.0.2.11,192.0.2.10",
+			want:      []string{"192.0.2.10", "192.0.2.11"},
+		},
+		{
+			name:      "IPs and hostnames sorted together",
+			allowlist: "node2.example.com,192.0.2.10,node1.example.com",
+			want:      []string{"192.0.2.10", "node1.example.com", "node2.example.com"},
+		},
+		{
+			name:      "mixed with CIDR excludes CIDR",
+			allowlist: "192.0.2.10,198.51.100.0/24,node1.example.com",
+			want:      []string{"192.0.2.10", "node1.example.com"},
+		},
+		{
+			name:      "hostname lowercased in output",
+			allowlist: "Node1.Example.COM",
+			want:      []string{"node1.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := ParseNodeAllowlist(tt.allowlist)
+			if err != nil {
+				t.Fatalf("ParseNodeAllowlist(%q) error: %v", tt.allowlist, err)
+			}
+
+			got := a.Exact()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Exact() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Closes #147

**Change ID:** add-mcp-completion-handler

Implements MCP `completion/complete` for prompt arguments and resource-template placeholders, so MCP clients (Claude Desktop, Cursor) can offer autosuggest for `node`, `namespace`, `service`, and `mode` fields instead of surfacing typos as gRPC errors at tool-call time.

**Scope note.** go-sdk v1.5.0 `CompleteReference.UnmarshalJSON` rejects any `ref.type` other than `ref/prompt` or `ref/resource`, matching MCP spec v2025-06-18. Tool-argument completion is therefore out of protocol scope for this SDK version; the issue's original "at least three tools" acceptance criterion was adjusted to cover the same information (nodes, namespace, service, mode) via prompts and resource templates.

### Changes

- `internal/talos/nodes.go` — new `NodeAllowlist.Exact()` enumerates normalized exact-match entries; CIDR ranges are intentionally excluded (cannot be enumerated as discrete candidates).
- `internal/completions/` — new package with `NewHandler` factory. Dispatches on `(ref.Type, promptName/URI, argName)`; backs node fields with the allowlist and service/namespace/mode fields with small curated tables (documented sources).
- `cmd/talos-mcp/main.go` — wires `ServerOptions.CompletionHandler = completions.NewHandler(allowedNodes)`. The SDK advertises the `completions` capability automatically.

### Review artifacts

- `staff-reviewer` → `escalate [architecture]` (new package + new protocol surface)
- `principal-architect-reviewer` → `approved` (clean API, no circular deps, no further escalation warranted)

Artifacts at `.claude/reviews/add-mcp-completion-handler/` (gitignored; local-only).

## Checklist

- [x] `make check` passes locally (fmt + vet + lint + test)
- [x] Commit messages follow conventional commits
- [x] New/changed tools include tests (10 new test functions; all dispatch branches + edge cases covered)
- [x] Documentation updated if applicable (N/A — README section on completion/complete is not currently documented; no user-facing env vars added)
