### PR TITLE
feat(subscriptions): MCP resource subscriptions via COSI watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Reads `~/.talos/config` by default (the same file `talosctl` uses). Override via
 | `TALOS_MCP_RATE_BURST` | `20` | HTTP mode: token-bucket burst capacity (int) |
 | `TALOS_MCP_MAX_BODY_SIZE` | `4194304` | HTTP mode: max POST request body size in bytes (4 MiB default) |
 | `TALOS_MCP_MAX_CONCURRENT` | `20` | HTTP mode: max concurrent POST handlers (fail-fast 503 on overload) |
+| `TALOS_MCP_SUBSCRIPTION_RATE` | `1s` | Minimum interval between delivered `resources/updated` notifications per `(session, URI)` pair (Go duration, e.g. `500ms`) |
+| `TALOS_MCP_SUBSCRIPTION_BURST` | `3` | Initial notification burst per `(session, URI)` before the rate kicks in |
 
 ## Compatibility
 
@@ -156,6 +158,27 @@ These tools modify cluster state and have explicit safety guards.
 | `talos_patch_config` | Apply a machine config patch (JSON or YAML strategic merge). | `dry_run` defaults to `true`; `confirm=true` required when `dry_run=false` |
 
 All tools accept an optional `nodes` field (list of node IPs or hostnames). When omitted, the active context from talosconfig is used.
+
+### Resources and Subscriptions
+
+The server exposes Talos COSI resources as MCP resources:
+
+- `talos://cluster/version` — static cluster version info.
+- `talos://cluster/resource-definitions` — discover resource types.
+- `talos://{node}/resource/{namespace}/{type}[/{id}]` — list or get COSI resources on a specific node.
+
+MCP clients that implement `resources/subscribe` (Claude Desktop, Cursor) receive `notifications/resources/updated` whenever the underlying resource changes — no polling required. Subscriptions are backed by the Talos COSI `Watch` / `WatchKindAggregated` streams and honour the same `TALOS_MCP_ALLOWED_NODES` allowlist as reads.
+
+Subscribable resource types (canonical names):
+
+- `MachineStatuses.runtime.talos.dev` (`MachineStatus`)
+- `Members.cluster.talos.dev` (`Member`)
+- `NodeAddresses.net.talos.dev` (`NodeAddress`)
+- `Services.v1alpha1.talos.dev` (`Service`)
+
+Aliases resolve to the canonical type before the allowlist check, so a client subscribing to `talos://{node}/resource/runtime/ms/...` (alias for `MachineStatus`) succeeds. Other COSI types reject with `resource type %q is not subscribable`. Static `talos://cluster/*` URIs are not subscribable (no COSI backing).
+
+Delivery is rate-limited per `(session, URI)` via `TALOS_MCP_SUBSCRIPTION_RATE` / `TALOS_MCP_SUBSCRIPTION_BURST`; over-rate events are dropped and the client re-reads the resource to catch up. The initial `Bootstrapped` event is intentionally not forwarded — the client is expected to call `resources/read` once after subscribe for initial state.
 
 ## Security Model
 

--- a/cmd/talos-mcp/main.go
+++ b/cmd/talos-mcp/main.go
@@ -24,6 +24,10 @@
 //   - TALOS_MCP_RATE_BURST: HTTP mode burst capacity (int, default 20)
 //   - TALOS_MCP_MAX_BODY_SIZE: HTTP mode max POST body bytes (int, default 4194304)
 //   - TALOS_MCP_MAX_CONCURRENT: HTTP mode max concurrent POST handlers (int, default 20)
+//   - TALOS_MCP_SUBSCRIPTION_RATE: minimum interval between delivered
+//     resources/updated notifications per (session, URI) (duration, default 1s)
+//   - TALOS_MCP_SUBSCRIPTION_BURST: initial notification burst per (session, URI)
+//     (int, default 3)
 package main
 
 import (
@@ -36,6 +40,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -46,6 +51,7 @@ import (
 	"github.com/Nosmoht/talos-mcp-server/internal/completions"
 	"github.com/Nosmoht/talos-mcp-server/internal/prompts"
 	"github.com/Nosmoht/talos-mcp-server/internal/resources"
+	"github.com/Nosmoht/talos-mcp-server/internal/subscriptions"
 	"github.com/Nosmoht/talos-mcp-server/internal/talos"
 	"github.com/Nosmoht/talos-mcp-server/internal/tools"
 	talosversion "github.com/Nosmoht/talos-mcp-server/internal/version"
@@ -138,6 +144,14 @@ func main() {
 		BlockedConfigPaths: blockedConfigPaths,
 	}
 
+	subRate, subBurst, err := parseSubscriptionLimits(os.Getenv("TALOS_MCP_SUBSCRIPTION_RATE"), os.Getenv("TALOS_MCP_SUBSCRIPTION_BURST"))
+	if err != nil {
+		stop()
+		log.Fatalf("%v", err) //nolint:gocritic // exitAfterDefer: stop() called explicitly above
+	}
+	subMgr := subscriptions.NewManager(tc, allowedNodes, subRate, subBurst)
+	defer subMgr.Shutdown()
+
 	serverOpts := &mcp.ServerOptions{
 		Instructions: "Talos Linux cluster management server. " +
 			"MCP Resources: read talos://cluster/resource-definitions to discover COSI resource types, " +
@@ -147,14 +161,17 @@ func main() {
 			"All tools accept an optional 'nodes' field to target specific node IPs; " +
 			"omit it to use the active context from talosconfig. " +
 			"Destructive tools (talos_reboot, talos_upgrade) require confirm=true and explicit nodes.",
-		CompletionHandler: completions.NewHandler(allowedNodes),
+		CompletionHandler:  completions.NewHandler(allowedNodes),
+		SubscribeHandler:   subMgr.Subscribe,
+		UnsubscribeHandler: subMgr.Unsubscribe,
 	}
 
+	// Wrap InitializedHandler. The supervisor goroutine runs unconditionally
+	// (subscriptions are per-session by SDK contract, unlike the logger which
+	// is stdio-only because multi-session HTTP would race the shared logger).
+	var priorInit func(context.Context, *mcp.InitializedRequest)
 	if httpAddr == "" {
-		// Stdio is single-session: wire per-session MCP log notifications.
-		// HTTP mode omits this — multiple concurrent sessions would race on the
-		// shared atomic.Pointer[slog.Logger], misdirecting notifications.
-		serverOpts.InitializedHandler = func(initCtx context.Context, req *mcp.InitializedRequest) {
+		priorInit = func(initCtx context.Context, req *mcp.InitializedRequest) {
 			logger := slog.New(mcp.NewLoggingHandler(req.Session, &mcp.LoggingHandlerOptions{
 				LoggerName: "talos-mcp",
 			}))
@@ -170,11 +187,21 @@ func main() {
 			}
 		}
 	}
+	serverOpts.InitializedHandler = func(initCtx context.Context, req *mcp.InitializedRequest) {
+		if priorInit != nil {
+			priorInit(initCtx, req)
+		}
+		go subMgr.SuperviseSession(req.Session)
+	}
 
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "talos",
 		Version: version,
 	}, serverOpts)
+
+	// BindServer must happen-before any session can issue resources/subscribe.
+	// Sessions start inside runServer below; binding here is sufficient.
+	subMgr.BindServer(server)
 
 	// All tools operate on a specific configured Talos cluster (closed world).
 	closedWorld := boolPtr(false)
@@ -486,6 +513,35 @@ func runServer(ctx context.Context, server *mcp.Server, addr, token string, hc h
 }
 
 // splitNonEmpty splits s by sep and returns non-empty, trimmed tokens.
+// parseSubscriptionLimits parses the rate/burst knobs for the subscription
+// manager, applying defaults when the env vars are unset. Returns an error
+// when a value is present but unparseable.
+func parseSubscriptionLimits(rateStr, burstStr string) (time.Duration, int, error) {
+	rate := time.Second
+	if rateStr != "" {
+		d, err := time.ParseDuration(rateStr)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid TALOS_MCP_SUBSCRIPTION_RATE: %w", err)
+		}
+		if d <= 0 {
+			return 0, 0, fmt.Errorf("TALOS_MCP_SUBSCRIPTION_RATE must be > 0, got %s", rateStr)
+		}
+		rate = d
+	}
+	burst := 3
+	if burstStr != "" {
+		n, err := strconv.Atoi(burstStr)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid TALOS_MCP_SUBSCRIPTION_BURST: %w", err)
+		}
+		if n <= 0 {
+			return 0, 0, fmt.Errorf("TALOS_MCP_SUBSCRIPTION_BURST must be > 0, got %d", n)
+		}
+		burst = n
+	}
+	return rate, burst, nil
+}
+
 // Returns nil when s is empty.
 func splitNonEmpty(s, sep string) []string {
 	if s == "" {

--- a/internal/resources/cosi.go
+++ b/internal/resources/cosi.go
@@ -15,7 +15,7 @@ import (
 const maxListResults = 100
 
 func (h *Handlers) handleCOSIResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-	node, ns, resType, resID, err := parseCOSIURI(req.Params.URI)
+	node, ns, resType, resID, err := ParseCOSIURI(req.Params.URI)
 	if err != nil {
 		return nil, fmt.Errorf("parse resource URI %q: %w", req.Params.URI, err)
 	}

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -51,7 +51,7 @@ func Register(server *mcp.Server, client *talos.Client, allowedNodes *talos.Node
 	}, h.handleCOSIResource)
 }
 
-// parseCOSIURI parses a COSI resource URI of the form:
+// ParseCOSIURI parses a COSI resource URI of the form:
 //
 //	talos://{node}/resource/{namespace}/{type}
 //	talos://{node}/resource/{namespace}/{type}/{id}
@@ -65,7 +65,7 @@ func Register(server *mcp.Server, client *talos.Client, allowedNodes *talos.Node
 // Hostname() (not Host) is used so that an optional port — e.g.
 // talos://10.0.0.1:50000/... — is stripped before passing the node
 // address to the Talos client.
-func parseCOSIURI(rawURI string) (node, namespace, resourceType, resourceID string, err error) {
+func ParseCOSIURI(rawURI string) (node, namespace, resourceType, resourceID string, err error) {
 	u, err := url.Parse(rawURI)
 	if err != nil {
 		return "", "", "", "", fmt.Errorf("parse URI: %w", err)

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -90,15 +90,15 @@ func TestParseCOSIURI(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			node, ns, typ, id, err := parseCOSIURI(tc.uri)
+			node, ns, typ, id, err := ParseCOSIURI(tc.uri)
 			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("parseCOSIURI(%q) = nil error, want error", tc.uri)
+					t.Fatalf("ParseCOSIURI(%q) = nil error, want error", tc.uri)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("parseCOSIURI(%q) error: %v", tc.uri, err)
+				t.Fatalf("ParseCOSIURI(%q) error: %v", tc.uri, err)
 			}
 			if node != tc.wantNode {
 				t.Errorf("node = %q, want %q", node, tc.wantNode)

--- a/internal/subscriptions/manager.go
+++ b/internal/subscriptions/manager.go
@@ -1,0 +1,306 @@
+// Package subscriptions implements the MCP resources/subscribe handler for
+// talos-mcp, backed by COSI Watch and WatchKindAggregated.
+//
+// The Manager owns one goroutine per (session, URI) subscription. Each
+// goroutine is rooted in a Manager-scoped context so it survives the
+// SubscribeRequest ctx (which ends the moment the JSON-RPC request returns)
+// and is torn down either by an explicit Unsubscribe, by the per-session
+// supervisor when the client disconnects, or by Shutdown signalling the
+// root context when the server itself terminates.
+//
+// Bootstrapped events from COSI Watch are intentionally dropped: the MCP
+// client is expected to call resources/read once after subscribe to obtain
+// initial state. Forwarding Bootstrapped risks a race against the SDK's
+// internal session-registration map (go-sdk mcp/server.go:892-909: the
+// SubscribeHandler returns before the session is inserted into
+// resourceSubscriptions, so a very-early ResourceUpdated call would be
+// dropped silently by the SDK).
+package subscriptions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	cosistate "github.com/cosi-project/runtime/pkg/state"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/time/rate"
+
+	"github.com/Nosmoht/talos-mcp-server/internal/resources"
+	"github.com/Nosmoht/talos-mcp-server/internal/talos"
+)
+
+// AllowedTypes is the set of canonical COSI resource types that clients may
+// subscribe to. Extending this set is cheap (single-line change) but each
+// new type should be reviewed for churn characteristics — NodeAddress on a
+// DHCP cluster is already close to the per-URI rate ceiling.
+var AllowedTypes = map[string]struct{}{
+	"MachineStatuses.runtime.talos.dev": {},
+	"Members.cluster.talos.dev":         {},
+	"NodeAddresses.net.talos.dev":       {},
+	"Services.v1alpha1.talos.dev":       {},
+}
+
+// notifyFunc is the injection seam that decouples the Manager from
+// *mcp.Server in tests. Production binds it to Server.ResourceUpdated
+// via BindServer.
+type notifyFunc func(ctx context.Context, uri string) error
+
+// Manager serializes subscribe/unsubscribe/supervise operations and owns the
+// long-lived goroutines that fan COSI Watch events into MCP notifications.
+type Manager struct {
+	client       talos.ClientInterface
+	allowedNodes *talos.NodeAllowlist
+	rateEvery    time.Duration
+	rateBurst    int
+	notify       atomic.Pointer[notifyFunc]
+
+	rootCtx    context.Context //nolint:containedctx // long-lived parent for every watcher; see package doc
+	rootCancel context.CancelFunc
+
+	mu       sync.Mutex
+	subs     map[subKey]*subscription
+	sessions map[string]map[string]struct{}
+}
+
+type subKey struct {
+	sessionID string
+	uri       string
+}
+
+type subscription struct {
+	cancel  context.CancelFunc
+	limiter *rate.Limiter
+}
+
+// NewManager builds a Manager rooted in a Background-derived context.
+// Call BindServer after the MCP server is constructed; call Shutdown from
+// main.go's cleanup path to drain all goroutines.
+func NewManager(client talos.ClientInterface, allowedNodes *talos.NodeAllowlist, rateEvery time.Duration, rateBurst int) *Manager {
+	root, cancel := context.WithCancel(context.Background())
+	return &Manager{
+		client:       client,
+		allowedNodes: allowedNodes,
+		rateEvery:    rateEvery,
+		rateBurst:    rateBurst,
+		rootCtx:      root,
+		rootCancel:   cancel,
+		subs:         make(map[subKey]*subscription),
+		sessions:     make(map[string]map[string]struct{}),
+	}
+}
+
+// BindServer installs the MCP server reference used to send
+// resources/updated notifications. It must be called before any session
+// can issue resources/subscribe. Because the SDK does not start sessions
+// until Server.Run / StreamableHTTPHandler is called, wiring BindServer
+// immediately after mcp.NewServer happens-before any subscribe call.
+func (m *Manager) BindServer(s *mcp.Server) {
+	fn := notifyFunc(func(ctx context.Context, uri string) error {
+		return s.ResourceUpdated(ctx, &mcp.ResourceUpdatedNotificationParams{URI: uri})
+	})
+	m.notify.Store(&fn)
+}
+
+// Shutdown cancels the root context; every watcher goroutine observes the
+// cancel on its next select and exits. Shutdown does not block on goroutine
+// completion — the caller (main.go's deferred teardown) exits the process
+// immediately after, and the Go runtime reaps remaining goroutines. Safe to
+// call multiple times.
+func (m *Manager) Shutdown() { m.rootCancel() }
+
+// Subscribe implements ServerOptions.SubscribeHandler.
+func (m *Manager) Subscribe(ctx context.Context, req *mcp.SubscribeRequest) error {
+	return m.subscribe(ctx, req.Session.ID(), req.Params.URI)
+}
+
+// Unsubscribe implements ServerOptions.UnsubscribeHandler.
+func (m *Manager) Unsubscribe(_ context.Context, req *mcp.UnsubscribeRequest) error {
+	m.unsubscribe(req.Session.ID(), req.Params.URI)
+	return nil
+}
+
+// SuperviseSession blocks on ss.Wait() and tears down every subscription
+// owned by the session when it disconnects. One supervisor goroutine per
+// session; installed from the wrapped InitializedHandler in main.go.
+func (m *Manager) SuperviseSession(ss *mcp.ServerSession) {
+	_ = ss.Wait()
+	m.cleanupSession(ss.ID())
+}
+
+// subscribe is the testable core of Subscribe, taking the session ID as an
+// explicit parameter so tests do not need a real *mcp.ServerSession.
+func (m *Manager) subscribe(ctx context.Context, sessionID, uri string) error {
+	node, ns, rawType, id, err := resources.ParseCOSIURI(uri)
+	if err != nil {
+		return fmt.Errorf("reject subscription: invalid URI %q: %w", uri, err)
+	}
+	if err := m.allowedNodes.CheckNode(node); err != nil {
+		return fmt.Errorf("reject subscription: %w", err)
+	}
+
+	namespace := resource.Namespace(ns)
+	rd, err := m.client.ResolveResourceKind(ctx, &namespace, rawType)
+	if err != nil {
+		return fmt.Errorf("reject subscription: resolve resource kind %q: %w", rawType, err)
+	}
+	canonical := rd.TypedSpec().Type
+	if _, ok := AllowedTypes[canonical]; !ok {
+		return fmt.Errorf("reject subscription: resource type %q is not subscribable", canonical)
+	}
+
+	key := subKey{sessionID: sessionID, uri: uri}
+
+	m.mu.Lock()
+	if _, dup := m.subs[key]; dup {
+		m.mu.Unlock()
+		slog.Debug("duplicate subscribe ignored", "session", sessionID, "uri", uri)
+		return nil
+	}
+
+	watchCtx, cancel := context.WithCancel(m.rootCtx) //nolint:gosec // G118: cancel is stored on sub and invoked by unsubscribe/cleanupSession/Shutdown
+	sub := &subscription{
+		cancel:  cancel,
+		limiter: rate.NewLimiter(rate.Every(m.rateEvery), m.rateBurst),
+	}
+	m.subs[key] = sub
+	if m.sessions[sessionID] == nil {
+		m.sessions[sessionID] = make(map[string]struct{})
+	}
+	m.sessions[sessionID][uri] = struct{}{}
+	m.mu.Unlock()
+
+	slog.Info("subscription opened", "session", sessionID, "uri", uri, "type", canonical)
+	go m.runWatch(watchCtx, key, namespace, canonical, id, sub.limiter)
+	return nil
+}
+
+// unsubscribe cancels and removes the (sessionID, uri) subscription if present.
+func (m *Manager) unsubscribe(sessionID, uri string) {
+	key := subKey{sessionID: sessionID, uri: uri}
+	m.mu.Lock()
+	sub, ok := m.subs[key]
+	if ok {
+		delete(m.subs, key)
+		if uris := m.sessions[sessionID]; uris != nil {
+			delete(uris, uri)
+			if len(uris) == 0 {
+				delete(m.sessions, sessionID)
+			}
+		}
+	}
+	m.mu.Unlock()
+	if ok {
+		sub.cancel()
+		slog.Info("subscription closed", "session", sessionID, "uri", uri)
+	}
+}
+
+// cleanupSession tears down every subscription owned by the session.
+// Cancels are collected under the mutex then invoked after the mutex is
+// released to avoid serializing the cancel chain behind the manager lock.
+func (m *Manager) cleanupSession(sessionID string) {
+	m.mu.Lock()
+	uris := m.sessions[sessionID]
+	cancels := make([]context.CancelFunc, 0, len(uris))
+	for uri := range uris {
+		if sub, ok := m.subs[subKey{sessionID: sessionID, uri: uri}]; ok {
+			cancels = append(cancels, sub.cancel)
+			delete(m.subs, subKey{sessionID: sessionID, uri: uri})
+		}
+	}
+	delete(m.sessions, sessionID)
+	m.mu.Unlock()
+	for _, c := range cancels {
+		c()
+	}
+	if len(cancels) > 0 {
+		slog.Info("session subscriptions torn down", "session", sessionID, "count", len(cancels))
+	}
+}
+
+// runWatch is the per-subscription goroutine. resourceID == "" selects the
+// list flavour via WatchKindAggregated; a non-empty ID selects single-resource
+// Watch. Channel buffers (32 for single, 8 for aggregated batches) prevent
+// the COSI publisher from blocking on downstream stalls.
+func (m *Manager) runWatch(ctx context.Context, key subKey, ns resource.Namespace, canonicalType, resourceID string, limiter *rate.Limiter) {
+	st := m.client.COSIState()
+
+	if resourceID == "" {
+		chAgg := make(chan []cosistate.Event, 8)
+		kind := resource.NewMetadata(ns, canonicalType, "", resource.VersionUndefined)
+		if err := st.WatchKindAggregated(ctx, kind, chAgg); err != nil {
+			if !errors.Is(err, context.Canceled) {
+				slog.Warn("watch kind start failed", "uri", key.uri, "error", err)
+			}
+			return
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case batch := <-chAgg:
+				for _, ev := range batch {
+					if !m.forwardEvent(ctx, key.uri, ev, limiter) {
+						return
+					}
+				}
+			}
+		}
+	}
+
+	ch := make(chan cosistate.Event, 32)
+	ptr := resource.NewMetadata(ns, canonicalType, resourceID, resource.VersionUndefined)
+	if err := st.Watch(ctx, ptr, ch); err != nil {
+		if !errors.Is(err, context.Canceled) {
+			slog.Warn("watch start failed", "uri", key.uri, "error", err)
+		}
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-ch:
+			if !m.forwardEvent(ctx, key.uri, ev, limiter) {
+				return
+			}
+		}
+	}
+}
+
+// forwardEvent classifies a single COSI event and (optionally) delivers an
+// MCP notification. Returns false when the goroutine should exit (Errored).
+func (m *Manager) forwardEvent(ctx context.Context, uri string, ev cosistate.Event, limiter *rate.Limiter) bool {
+	switch ev.Type {
+	case cosistate.Bootstrapped:
+		// Drop — initial state belongs to resources/read, and forwarding here
+		// risks the SDK register-subscriber race described in the package doc.
+		return true
+	case cosistate.Errored:
+		slog.Warn("watch error", "uri", uri, "error", ev.Error)
+		return false
+	case cosistate.Created, cosistate.Updated, cosistate.Destroyed, cosistate.Noop:
+		if ev.Type == cosistate.Noop {
+			return true // Noop is a no-change marker; clients already have the current state.
+		}
+		if !limiter.Allow() {
+			slog.Debug("notification dropped by rate limiter", "uri", uri)
+			return true
+		}
+		fn := m.notify.Load()
+		if fn == nil {
+			slog.Warn("ResourceUpdated skipped: server not bound", "uri", uri)
+			return false
+		}
+		if err := (*fn)(ctx, uri); err != nil {
+			slog.Warn("ResourceUpdated failed", "uri", uri, "error", err)
+		}
+	}
+	return true
+}

--- a/internal/subscriptions/manager_test.go
+++ b/internal/subscriptions/manager_test.go
@@ -1,0 +1,528 @@
+package subscriptions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/meta/spec"
+	cosistate "github.com/cosi-project/runtime/pkg/state"
+	"google.golang.org/grpc"
+
+	clusterapi "github.com/siderolabs/talos/pkg/machinery/api/cluster"
+	commonapi "github.com/siderolabs/talos/pkg/machinery/api/common"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	"io"
+
+	"github.com/Nosmoht/talos-mcp-server/internal/talos"
+	"github.com/Nosmoht/talos-mcp-server/internal/version"
+)
+
+// ── Fakes ────────────────────────────────────────────────────────────────────
+
+// fakeCore implements state.CoreState enough for Manager's Watch paths.
+// All other methods panic — tests never reach them.
+type fakeCore struct {
+	mu                sync.Mutex
+	singleCh          chan<- cosistate.Event
+	aggCh             chan<- []cosistate.Event
+	watchStartErr     error
+	watchKindStartErr error
+}
+
+func (f *fakeCore) emit(ev cosistate.Event) {
+	f.mu.Lock()
+	ch := f.singleCh
+	f.mu.Unlock()
+	if ch != nil {
+		ch <- ev
+	}
+}
+
+func (f *fakeCore) emitBatch(evs []cosistate.Event) {
+	f.mu.Lock()
+	ch := f.aggCh
+	f.mu.Unlock()
+	if ch != nil {
+		ch <- evs
+	}
+}
+
+func (f *fakeCore) Get(context.Context, resource.Pointer, ...cosistate.GetOption) (resource.Resource, error) {
+	panic("Get not used in tests")
+}
+
+func (f *fakeCore) List(context.Context, resource.Kind, ...cosistate.ListOption) (resource.List, error) {
+	panic("List not used in tests")
+}
+
+func (f *fakeCore) Create(context.Context, resource.Resource, ...cosistate.CreateOption) error {
+	panic("Create not used in tests")
+}
+
+func (f *fakeCore) Update(context.Context, resource.Resource, ...cosistate.UpdateOption) error {
+	panic("Update not used in tests")
+}
+
+func (f *fakeCore) Destroy(context.Context, resource.Pointer, ...cosistate.DestroyOption) error {
+	panic("Destroy not used in tests")
+}
+
+func (f *fakeCore) Watch(ctx context.Context, _ resource.Pointer, ch chan<- cosistate.Event, _ ...cosistate.WatchOption) error {
+	if f.watchStartErr != nil {
+		return f.watchStartErr
+	}
+	f.mu.Lock()
+	f.singleCh = ch
+	f.mu.Unlock()
+	go func() {
+		<-ctx.Done()
+	}()
+	return nil
+}
+
+func (f *fakeCore) WatchKind(_ context.Context, _ resource.Kind, _ chan<- cosistate.Event, _ ...cosistate.WatchKindOption) error {
+	return errors.New("WatchKind not used")
+}
+
+func (f *fakeCore) WatchKindAggregated(ctx context.Context, _ resource.Kind, ch chan<- []cosistate.Event, _ ...cosistate.WatchKindOption) error {
+	if f.watchKindStartErr != nil {
+		return f.watchKindStartErr
+	}
+	f.mu.Lock()
+	f.aggCh = ch
+	f.mu.Unlock()
+	go func() {
+		<-ctx.Done()
+	}()
+	return nil
+}
+
+// fakeClient is a minimal talos.ClientInterface that exposes a fakeCore via
+// COSIState() and resolves resource kinds from a static map.
+type fakeClient struct {
+	state *cosistate.State
+	kinds map[string]*meta.ResourceDefinition // rawType → canonical definition
+}
+
+var _ talos.ClientInterface = (*fakeClient)(nil)
+
+func (f *fakeClient) COSIState() cosistate.State { return *f.state }
+
+func (f *fakeClient) ResolveResourceKind(_ context.Context, _ *resource.Namespace, rawType resource.Type) (*meta.ResourceDefinition, error) {
+	if rd, ok := f.kinds[rawType]; ok {
+		return rd, nil
+	}
+	return nil, fmt.Errorf("unknown resource type %q", rawType)
+}
+
+// All other ClientInterface methods are unused; unreachable panics keep
+// tests honest.
+func (f *fakeClient) Version(context.Context, ...grpc.CallOption) (*machineapi.VersionResponse, error) {
+	panic("Version unused")
+}
+func (f *fakeClient) ServiceList(context.Context, ...grpc.CallOption) (*machineapi.ServiceListResponse, error) {
+	panic("ServiceList unused")
+}
+func (f *fakeClient) ServiceStart(context.Context, string, ...grpc.CallOption) (*machineapi.ServiceStartResponse, error) {
+	panic("ServiceStart unused")
+}
+func (f *fakeClient) ServiceStop(context.Context, string, ...grpc.CallOption) (*machineapi.ServiceStopResponse, error) {
+	panic("ServiceStop unused")
+}
+func (f *fakeClient) ServiceRestart(context.Context, string, ...grpc.CallOption) (*machineapi.ServiceRestartResponse, error) {
+	panic("ServiceRestart unused")
+}
+func (f *fakeClient) Containers(context.Context, string, commonapi.ContainerDriver, ...grpc.CallOption) (*machineapi.ContainersResponse, error) {
+	panic("Containers unused")
+}
+func (f *fakeClient) Processes(context.Context, ...grpc.CallOption) (*machineapi.ProcessesResponse, error) {
+	panic("Processes unused")
+}
+func (f *fakeClient) ClusterHealthCheck(context.Context, time.Duration, *clusterapi.ClusterInfo) (clusterapi.ClusterService_HealthCheckClient, error) {
+	panic("ClusterHealthCheck unused")
+}
+func (f *fakeClient) Reboot(context.Context, ...talosclient.RebootMode) error { panic("Reboot unused") }
+func (f *fakeClient) UpgradeWithOptions(context.Context, ...talosclient.UpgradeOption) (*machineapi.UpgradeResponse, error) {
+	panic("UpgradeWithOptions unused")
+}
+func (f *fakeClient) Rollback(context.Context) error { panic("Rollback unused") }
+func (f *fakeClient) ApplyConfiguration(context.Context, *machineapi.ApplyConfigurationRequest, ...grpc.CallOption) (*machineapi.ApplyConfigurationResponse, error) {
+	panic("ApplyConfiguration unused")
+}
+func (f *fakeClient) ResetGenericWithResponse(context.Context, *machineapi.ResetRequest) (*machineapi.ResetResponse, error) {
+	panic("ResetGenericWithResponse unused")
+}
+func (f *fakeClient) Logs(context.Context, string, commonapi.ContainerDriver, string, bool, int32) (machineapi.MachineService_LogsClient, error) {
+	panic("Logs unused")
+}
+func (f *fakeClient) Dmesg(context.Context, bool, bool) (machineapi.MachineService_DmesgClient, error) {
+	panic("Dmesg unused")
+}
+func (f *fakeClient) EventsWatch(context.Context, func(<-chan talosclient.Event), ...talosclient.EventsOptionFunc) error {
+	panic("EventsWatch unused")
+}
+func (f *fakeClient) LS(context.Context, *machineapi.ListRequest) (machineapi.MachineService_ListClient, error) {
+	panic("LS unused")
+}
+func (f *fakeClient) Read(context.Context, string) (io.ReadCloser, error) { panic("Read unused") }
+func (f *fakeClient) EtcdMemberList(context.Context, *machineapi.EtcdMemberListRequest, ...grpc.CallOption) (*machineapi.EtcdMemberListResponse, error) {
+	panic("EtcdMemberList unused")
+}
+func (f *fakeClient) EtcdStatus(context.Context, ...grpc.CallOption) (*machineapi.EtcdStatusResponse, error) {
+	panic("EtcdStatus unused")
+}
+func (f *fakeClient) EtcdSnapshot(context.Context, *machineapi.EtcdSnapshotRequest, ...grpc.CallOption) (io.ReadCloser, error) {
+	panic("EtcdSnapshot unused")
+}
+func (f *fakeClient) GetNodeVersion(context.Context, string) (*version.TalosVersion, error) {
+	panic("GetNodeVersion unused")
+}
+func (f *fakeClient) GetClusterVersion(context.Context) (*version.TalosVersion, error) {
+	panic("GetClusterVersion unused")
+}
+func (f *fakeClient) InvalidateVersionCache()    { panic("InvalidateVersionCache unused") }
+func (f *fakeClient) Ping(context.Context) error { panic("Ping unused") }
+
+// ── Test setup helpers ──────────────────────────────────────────────────────
+
+const (
+	testNode       = "192.0.2.10"
+	testURIList    = "talos://192.0.2.10/resource/runtime/MachineStatus"
+	testURIItem    = "talos://192.0.2.10/resource/runtime/MachineStatus/node-1"
+	testClusterURI = "talos://cluster/version"
+)
+
+func makeResourceDef(canonical string) *meta.ResourceDefinition {
+	rd, err := meta.NewResourceDefinition(spec.ResourceDefinitionSpec{
+		Type:             canonical,
+		DefaultNamespace: "runtime",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return rd
+}
+
+// setup builds a Manager + fakeCore pair with allowedNodes set to testNode.
+// rateEvery is very tight (1 µs) so tests don't rely on wall-clock timing.
+func setup(t *testing.T, burst int) (*Manager, *fakeCore, func(uri string)) {
+	t.Helper()
+
+	allow, err := talos.ParseNodeAllowlist(testNode)
+	if err != nil {
+		t.Fatalf("ParseNodeAllowlist: %v", err)
+	}
+
+	fc := &fakeCore{}
+	st := cosistate.WrapCore(fc)
+
+	kinds := map[string]*meta.ResourceDefinition{
+		"MachineStatus": makeResourceDef("MachineStatuses.runtime.talos.dev"),
+		"ms":            makeResourceDef("MachineStatuses.runtime.talos.dev"),
+		"Member":        makeResourceDef("Members.cluster.talos.dev"),
+		"NodeAddress":   makeResourceDef("NodeAddresses.net.talos.dev"),
+		"Service":       makeResourceDef("Services.v1alpha1.talos.dev"),
+		"LinkStatus":    makeResourceDef("LinkStatuses.net.talos.dev"), // NOT in allowlist
+	}
+
+	fake := &fakeClient{state: &st, kinds: kinds}
+	m := NewManager(fake, allow, time.Microsecond, burst)
+
+	notified := make(chan string, 64)
+	fn := notifyFunc(func(_ context.Context, uri string) error {
+		notified <- uri
+		return nil
+	})
+	m.notify.Store(&fn)
+
+	t.Cleanup(func() { m.Shutdown() })
+
+	expect := func(wantURI string) {
+		t.Helper()
+		select {
+		case got := <-notified:
+			if got != wantURI {
+				t.Errorf("notification URI = %q, want %q", got, wantURI)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("no notification within timeout (wanted %q)", wantURI)
+		}
+	}
+	return m, fc, expect
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+func TestSubscribe_SingleResource_Delivers(t *testing.T) {
+	m, fc, expect := setup(t, 5)
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	// Give runWatch a tick to call Watch and record singleCh.
+	time.Sleep(10 * time.Millisecond)
+	fc.emit(cosistate.Event{Type: cosistate.Updated})
+	expect(testURIItem)
+}
+
+func TestSubscribe_ListURI_DeliversAggregated(t *testing.T) {
+	m, fc, expect := setup(t, 5)
+	if err := m.subscribe(context.Background(), "sess-A", testURIList); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	fc.emitBatch([]cosistate.Event{{Type: cosistate.Updated}, {Type: cosistate.Created}})
+	expect(testURIList)
+	expect(testURIList)
+}
+
+func TestSubscribe_ClusterURI_Rejected(t *testing.T) {
+	m, _, _ := setup(t, 5)
+	err := m.subscribe(context.Background(), "sess-A", testClusterURI)
+	if err == nil || !strings.Contains(err.Error(), "invalid URI") {
+		t.Errorf("cluster URI should reject with 'invalid URI': %v", err)
+	}
+}
+
+func TestSubscribe_DisallowedType_Rejected(t *testing.T) {
+	m, _, _ := setup(t, 5)
+	uri := "talos://192.0.2.10/resource/net/LinkStatus/eth0"
+	err := m.subscribe(context.Background(), "sess-A", uri)
+	if err == nil || !strings.Contains(err.Error(), "not subscribable") {
+		t.Errorf("LinkStatus should reject with 'not subscribable': %v", err)
+	}
+}
+
+func TestSubscribe_Alias_ResolvesThenAllowlisted(t *testing.T) {
+	m, fc, expect := setup(t, 5)
+	// Alias "ms" resolves to canonical MachineStatuses.runtime.talos.dev which IS in AllowedTypes.
+	uri := "talos://192.0.2.10/resource/runtime/ms/node-1"
+	if err := m.subscribe(context.Background(), "sess-A", uri); err != nil {
+		t.Fatalf("alias subscribe should succeed: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	fc.emit(cosistate.Event{Type: cosistate.Updated})
+	expect(uri)
+}
+
+func TestSubscribe_NodeNotAllowed_Rejected(t *testing.T) {
+	m, _, _ := setup(t, 5)
+	uri := "talos://203.0.113.1/resource/runtime/MachineStatus/node-1"
+	err := m.subscribe(context.Background(), "sess-A", uri)
+	if err == nil || !strings.Contains(err.Error(), "not in the allowed nodes") {
+		t.Errorf("non-allowlist node should reject: %v", err)
+	}
+}
+
+func TestBootstrapped_Dropped(t *testing.T) {
+	m, fc, _ := setup(t, 5)
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	fc.emit(cosistate.Event{Type: cosistate.Bootstrapped})
+
+	// Bootstrapped must NOT produce a notification.
+	notified := make(chan struct{}, 1)
+	fn := notifyFunc(func(context.Context, string) error {
+		notified <- struct{}{}
+		return nil
+	})
+	m.notify.Store(&fn)
+	fc.emit(cosistate.Event{Type: cosistate.Bootstrapped})
+	select {
+	case <-notified:
+		t.Error("Bootstrapped event was forwarded")
+	case <-time.After(100 * time.Millisecond):
+		// good — dropped
+	}
+}
+
+func TestErrored_StopsGoroutine(t *testing.T) {
+	m, fc, _ := setup(t, 5)
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	fc.emit(cosistate.Event{Type: cosistate.Errored, Error: errors.New("node down")})
+	// Give the goroutine a moment to exit; subsequent events must not deliver.
+	time.Sleep(20 * time.Millisecond)
+
+	delivered := make(chan struct{}, 1)
+	fn := notifyFunc(func(context.Context, string) error {
+		delivered <- struct{}{}
+		return nil
+	})
+	m.notify.Store(&fn)
+	fc.emit(cosistate.Event{Type: cosistate.Updated})
+	select {
+	case <-delivered:
+		t.Error("goroutine delivered after Errored — it should have exited")
+	case <-time.After(100 * time.Millisecond):
+		// good
+	}
+}
+
+func TestUnsubscribe_CancelsGoroutine(t *testing.T) {
+	m, fc, _ := setup(t, 5)
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	m.unsubscribe("sess-A", testURIItem)
+
+	// Verify the sub is gone from the map.
+	m.mu.Lock()
+	_, present := m.subs[subKey{sessionID: "sess-A", uri: testURIItem}]
+	m.mu.Unlock()
+	if present {
+		t.Error("subscription still present after unsubscribe")
+	}
+	// Event after cancel must not deliver (channel send into closed ctx is drained by goroutine exit).
+	delivered := make(chan struct{}, 1)
+	fn := notifyFunc(func(context.Context, string) error {
+		delivered <- struct{}{}
+		return nil
+	})
+	m.notify.Store(&fn)
+	time.Sleep(10 * time.Millisecond)
+	select {
+	case fc.singleCh <- cosistate.Event{Type: cosistate.Updated}:
+		// non-blocking send: channel buffer absorbs; goroutine has exited so no read happens.
+	default:
+	}
+	select {
+	case <-delivered:
+		t.Error("delivered after unsubscribe")
+	case <-time.After(50 * time.Millisecond):
+		// good
+	}
+}
+
+func TestSupervisor_TearsDownAllSessionURIs(t *testing.T) {
+	m, _, _ := setup(t, 5)
+	ctx := context.Background()
+	if err := m.subscribe(ctx, "sess-X", testURIItem); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.subscribe(ctx, "sess-X", testURIList); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	m.cleanupSession("sess-X")
+
+	m.mu.Lock()
+	remaining := len(m.subs) + len(m.sessions)
+	m.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("after cleanupSession, subs+sessions = %d, want 0", remaining)
+	}
+}
+
+func TestRateLimiter_DropsOverBurst(t *testing.T) {
+	// Much slower rate than the other tests so we can observe drops.
+	allow, _ := talos.ParseNodeAllowlist(testNode)
+	fc := &fakeCore{}
+	st := cosistate.WrapCore(fc)
+	fake := &fakeClient{
+		state: &st,
+		kinds: map[string]*meta.ResourceDefinition{
+			"MachineStatus": makeResourceDef("MachineStatuses.runtime.talos.dev"),
+		},
+	}
+	m := NewManager(fake, allow, time.Second, 3) // 1/s, burst 3
+	t.Cleanup(m.Shutdown)
+
+	var count atomic.Int32
+	fn := notifyFunc(func(context.Context, string) error {
+		count.Add(1)
+		return nil
+	})
+	m.notify.Store(&fn)
+
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	for i := 0; i < 10; i++ {
+		fc.emit(cosistate.Event{Type: cosistate.Updated})
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := count.Load(); got > 4 {
+		t.Errorf("delivered %d events, want ≤ 4 (burst 3 + at most 1 from rate)", got)
+	}
+}
+
+func TestDuplicateSubscribe_Idempotent(t *testing.T) {
+	m, _, _ := setup(t, 5)
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Errorf("duplicate subscribe should be idempotent, got: %v", err)
+	}
+	m.mu.Lock()
+	got := len(m.subs)
+	m.mu.Unlock()
+	if got != 1 {
+		t.Errorf("sub count = %d, want 1 (no double entry)", got)
+	}
+}
+
+func TestNotifierUnboundExitsGoroutine(t *testing.T) {
+	// A fresh manager without notify bound.
+	allow, _ := talos.ParseNodeAllowlist(testNode)
+	fc := &fakeCore{}
+	st := cosistate.WrapCore(fc)
+	fake := &fakeClient{
+		state: &st,
+		kinds: map[string]*meta.ResourceDefinition{
+			"MachineStatus": makeResourceDef("MachineStatuses.runtime.talos.dev"),
+		},
+	}
+	m := NewManager(fake, allow, time.Microsecond, 5)
+	t.Cleanup(m.Shutdown)
+	// notify NOT set
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	fc.emit(cosistate.Event{Type: cosistate.Updated})
+
+	// After the event, the goroutine should have exited (warned + returned false).
+	// Verify by emitting a second event — it must not block forever.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		select {
+		case fc.singleCh <- cosistate.Event{Type: cosistate.Updated}:
+		default:
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Error("second emit hung; goroutine did not exit after nil notifier")
+	}
+}
+
+func TestReSubscribeAfterUnsubscribe(t *testing.T) {
+	m, _, _ := setup(t, 5)
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Fatal(err)
+	}
+	m.unsubscribe("sess-A", testURIItem)
+	if err := m.subscribe(context.Background(), "sess-A", testURIItem); err != nil {
+		t.Errorf("re-subscribe after unsubscribe failed: %v", err)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Closes #148

**Change ID:** add-resource-subscriptions

Implements MCP `resources/subscribe` backed by Talos COSI `Watch` and `WatchKindAggregated`. Clients that support the subscription protocol (Claude Desktop, Cursor) receive `notifications/resources/updated` instead of polling, reducing token burn on reactive agents and cutting gRPC load on churning clusters.

Additive only — existing read handlers and tools are untouched. New protocol surface is limited to subscribe/unsubscribe + ResourceUpdated.

### Scope

- Single-resource URIs: `talos://{node}/resource/{ns}/{type}/{id}` → COSI `Watch`.
- List URIs: `talos://{node}/resource/{ns}/{type}` → COSI `WatchKindAggregated`.
- Canonical type allowlist: `MachineStatus`, `Member`, `NodeAddress`, `Service`. Aliases resolve to canonical before the allowlist check so alias bypass is impossible.
- Static `talos://cluster/*` URIs are **not** subscribable (no COSI backing).

### Safety

- Node allowlist reused — cannot subscribe to nodes you cannot read.
- Per-session supervisor drains every subscription on client disconnect via `ss.Wait()`; `Shutdown` cancels the manager-scoped root context on process exit.
- Per `(session, URI)` rate limiter (`TALOS_MCP_SUBSCRIPTION_RATE`, `TALOS_MCP_SUBSCRIPTION_BURST`) guards against noisy resources (`NodeAddress` on DHCP-churn clusters).
- COSI `Bootstrapped` events are intentionally dropped; clients call `resources/read` once after subscribe for initial state. This also side-steps the SDK register-subscriber micro-race between `SubscribeHandler` return and the internal `resourceSubscriptions` map insert.

### Review artifacts

- `staff-reviewer` → `escalate` (after README fix)
- `principal-architect-reviewer` → `approved`
- `compatibility-reviewer` → `approved`
- `performance-reviewer` → `approved`

Artifacts at `.claude/reviews/add-resource-subscriptions/` (gitignored, local-only).

## Checklist

- [x] `make check` passes locally (fmt + vet + revive + gocritic + gosec + errorlint + exhaustive + thelper + tests)
- [x] Commit messages follow conventional commits
- [x] New/changed tools include tests (13 dispatch/edge cases in `internal/subscriptions/manager_test.go`)
- [x] Documentation updated: README.md § Configuration + § Resources and Subscriptions
