### PR TITLE
fix(registry): shorten server.json description to 100-char limit and surface registry validation errors

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -3,9 +3,13 @@ name: auto-tag
 on:
   push:
     branches: [main]
-    # Only tag when server code changes. npm/ is excluded intentionally: npm wrapper
-    # changes cannot alter the compiled binary and should not trigger a release without
-    # Go CI validation. NOTE: keep this path list in sync with ci.yml 'changes' job.
+    # Only tag when server code or release-relevant metadata changes. npm/ is excluded
+    # intentionally: npm wrapper changes cannot alter the compiled binary and should not
+    # trigger a release without Go CI validation. server.json IS included because the
+    # mcp-registry-publish job (in release.yml) consumes it — a description / metadata
+    # fix needs a patch release to reach the registry. NOTE: keep this path list in sync
+    # with ci.yml 'changes' job for Go-relevant entries; server.json is intentionally
+    # outside the Go filter (server.json-only PRs skip Go lint/test, which is correct).
     paths:
       - '*.go'
       - 'cmd/**'
@@ -14,6 +18,7 @@ on:
       - 'go.sum'
       - 'Makefile'
       - '.goreleaser.yaml'
+      - 'server.json'
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,11 +118,15 @@ jobs:
 
   # NOTE: Registry publish runs after npm-publish so the registry can verify
   # the npm package (with mcpName) exists before accepting the server entry.
-  # continue-on-error: registry outages must not fail the primary release artifacts.
+  # Fail-loud: continue-on-error was previously true to shield primary release
+  # artifacts from registry outages, but it also hid validation rejections (e.g.
+  # v2.3.0 silently failed with HTTP 422 on a description-too-long error). The
+  # surfaced trade-off — a real registry 5xx now fails the release run — is
+  # preferred over silent breakage. If registry outages become a recurring noise
+  # source, consider differentiating 4xx (our config bug) from 5xx (their fault).
   mcp-registry-publish:
     needs: npm-publish
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
       id-token: write

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Nosmoht/talos-mcp-server",
   "title": "Talos Linux MCP Server",
-  "description": "Manage Talos Linux clusters via the native gRPC API. Tools for resources, services, logs, health checks, config patching, and lifecycle operations.",
+  "description": "MCP server for Talos Linux — resources, services, logs, health, config, lifecycle via gRPC.",
   "version": "0.0.0",
   "repository": {
     "url": "https://github.com/Nosmoht/talos-mcp-server",


### PR DESCRIPTION
## What does this PR do?

**Change ID:** `registry-description-limit`

Fixes the silent CI failure that caused `v2.3.0` (commit `223a0c0`) not to publish to `registry.modelcontextprotocol.io`.

### Root cause

The `mcp-registry-publish` job returned HTTP 422 from the registry:

```
expected length <= 100   location: body.description
value: "Manage Talos Linux clusters via the native gRPC API. ..."   (147 chars)
```

`continue-on-error: true` on the job hid the failure — the overall release run reported `success` while the registry entry was skipped. `goreleaser` and `npm-publish` ran green; only the MCP Registry is missing v2.3.0.

### Three fixes in this PR

1. **`server.json`** — description shortened from 147 → 91 codepoints. The 100-char ceiling is enforced by the registry's `2025-12-11.json` schema and `pkg/api/v0/types.go` (verified via the registry source). New text reuses CLAUDE.md vocabulary (`MCP server`, `Talos Linux`, `via gRPC`).
2. **`.github/workflows/auto-tag.yml`** — `server.json` added to the `paths:` trigger list. Without this, a server.json-only fix wouldn't produce a tag and the registry would stay broken. The inline NOTE comment explains the npm/ vs server.json asymmetry.
3. **`.github/workflows/release.yml`** — `continue-on-error: true` removed from the `mcp-registry-publish` job. Future validation rejections now surface as a red release run. Trade-off (real registry 5xx outage will also fail the release) is documented in the comment block with a suggested mitigation if it becomes recurring.

### Out of scope

- Re-publishing v2.3.0 retroactively. The next patch release supersedes it on the registry; no manual catch-up needed.
- A pre-commit / CI hook that validates `server.json` against the published JSON schema. Nice-to-have, but the post-merge fail-loud guard already prevents silent regressions.

## Checklist

- [x] `make check` passes locally (fmt + vet + lint + test) — no Go change; full suite green
- [x] Commit message follows conventional commits (`fix(registry): … [review:registry-description-limit]`)
- [x] `jq -r '.description | length' server.json` returns `91`
- [x] Documentation updated — comment blocks in both workflow files explain the new behaviour and trade-offs

## Review

`staff-reviewer` artifact at `.claude/reviews/registry-description-limit/review.md`: **approved**, change-category `ci`, no findings, no escalations. Reviewer also independently verified em-dash UTF-8 encoding (`e2 80 94` = U+2014, single codepoint) and confirmed `ci.yml` correctly leaves server.json out of the Go-changes filter so server.json-only PRs skip Go lint/test.

## Verification post-merge

1. `auto-tag.yml` fires (now that `server.json` is in `paths:`) → bumps to `v2.3.1`
2. `release.yml` runs on the new tag
3. `mcp-registry-publish` job exits `success` (no longer hidden by `continue-on-error`)
4. `curl -s https://registry.modelcontextprotocol.io/v0/servers/io.github.Nosmoht/talos-mcp-server | jq '.version'` returns `2.3.1`

## Related

- Tag `v2.3.0` (commit `223a0c0`) is the affected release; it stays on npm + GitHub Releases but is missing from the MCP Registry.
- Independent of PR #154 (P0 safety prereqs), which is also in flight against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)