### PR TITLE
docs(claude): bake PR #154 review findings into rules/skills/agents

### DIFF
--- a/.claude/agents/compatibility-reviewer.md
+++ b/.claude/agents/compatibility-reviewer.md
@@ -57,7 +57,7 @@ For each modified tool handler and its `Args` struct:
 ### Tool Naming and Registration
 
 - [ ] **Consistent naming pattern**: Tool names follow `talos_<verb>` or `talos_<noun>_<verb>` convention
-- [ ] **Tool registered in correct mode**: Mutating tools only in `if !readOnly { }` block in `cmd/talos-mcp/main.go`
+- [ ] **Tool registered in correct mode**: Mutating tools only in `if !readOnly { }` block in `internal/tools/register.go`
 - [ ] **README.md tool table updated**: New tools appear in the tool list; count and description are accurate
 
 ### Prompt and Resource Compatibility

--- a/.claude/agents/operational-safety-reviewer.md
+++ b/.claude/agents/operational-safety-reviewer.md
@@ -69,7 +69,7 @@ For every mutating tool (`talos_reboot`, `talos_upgrade`, `talos_rollback`, `tal
 
 ### TALOS_MCP_READ_ONLY Enforcement
 
-- [ ] **New mutating tools registered conditionally**: Any new mutating tool must be registered inside the `if !readOnly { ... }` block in `cmd/talos-mcp/main.go`
+- [ ] **New mutating tools registered conditionally**: Any new mutating tool must be registered inside the `if !readOnly { ... }` block in `internal/tools/register.go`
 - [ ] **Not registered in read-only mode**: Verify by reading the server registration code
 
 ## Output Format

--- a/.claude/agents/staff-reviewer.md
+++ b/.claude/agents/staff-reviewer.md
@@ -27,7 +27,7 @@ Approved output:
 
 <example>
 Context: New talos_drain_node mutating tool added.
-Input: New handler in internal/tools/lifecycle.go, registered in cmd/talos-mcp/main.go.
+Input: New handler in internal/tools/lifecycle.go, registered in internal/tools/register.go.
 Escalation output:
   change-id: add-drain-node-tool
   review-type: review

--- a/.claude/rules/quorum-member-counting.md
+++ b/.claude/rules/quorum-member-counting.md
@@ -1,0 +1,12 @@
+# Quorum / Cluster-Member Counting
+
+When counting cluster members (etcd, Kubernetes, any consensus group) for a quorum or strict-majority decision:
+
+- **Deduplicate by member ID before counting.** A Talos API proxy or gRPC stream aggregation can emit the same `EtcdMember` / `Member` across multiple `Messages[]` entries, so `len(msg.GetMembers())` is not a safe count.
+- **Use the raft node `Id` (`uint64`), not hostname or peer URL.** Hostnames can be missing for learners or nodes that have not yet advertised a peer URL — `Id` is etcd's canonical identity and matches its own dedup semantics.
+- **Record the ID type in the helper's doc comment** so reviewers can verify the dedup structure (`map[uint64]struct{}` for etcd, typed equivalent for other consensus groups).
+- The strict-majority rule `(healthy - remove) > configured/2` is only sound when `configured` is the deduplicated count. An inflated count can let the gate pass when it must fail — a silent path to a dangerous mutation.
+
+Applies to all preflight helpers under `internal/tools/` that inform mutating decisions (etcd remove/leave, k8s control-plane rotation, future consensus-group mutators). Canonical implementation: `fetchEtcdMemberCount` in `internal/tools/etcd_preflight.go`.
+
+**Learner caveat:** etcd learners (`IsLearner=true`) do not count toward quorum. Dedup alone does not filter learners — any helper that computes voting-member majority must also filter by `IsLearner`.

--- a/.claude/skills/add-mcp-tool/references/safety-defaults.md
+++ b/.claude/skills/add-mcp-tool/references/safety-defaults.md
@@ -18,3 +18,13 @@ Source of truth: repo root `CLAUDE.md` § Safety.
 - Config-mutating tools MUST default `dry_run=true`.
 - Never wipe secrets via context — `talos_apply_config` takes a local file path only.
 - `system_labels_to_wipe` empty on `talos_reset` = full disk wipe; document loudly.
+
+## Confirm-guard invariants (enforced by `internal/tools/invariants_test.go`)
+
+- Every mutating tool MUST carry a `Confirm bool` field in its args struct. Every destructive tool registration MUST carry a `confirm` property in its `InputSchema`.
+- The invariants test runs on every CI build: destructive tools never leak through `readOnly=true` registration, and every destructive tool's schema advertises `confirm`.
+- If a new mutating tool legitimately cannot carry `Confirm` yet (rare — requires justification in the PR description), add it to `knownConfirmGapTools` in `invariants_test.go` **and** file a tracking GitHub issue (`type: chore`, `priority: P2`, `area: tools`, `origin: audit`) referencing the waiver. The `t.Logf` line is not a tracker — missing issues are a process failure. Reference: issue #156 is the canonical example (`talos_service_action` waiver).
+
+## Preflight helpers
+
+Any new `*_preflight.go` helper that informs a mutating decision must follow `.claude/rules/quorum-member-counting.md`: dedup cluster members by ID (`uint64` for etcd) before counting, never trust `len(msg.GetMembers())`.

--- a/.claude/skills/guard-mutating-tool/SKILL.md
+++ b/.claude/skills/guard-mutating-tool/SKILL.md
@@ -30,10 +30,11 @@ git rev-parse --verify "${BASE:-origin/main}" >/dev/null \
    ```bash
    git diff --name-only "${BASE:-origin/main}"...HEAD -- 'internal/tools/*.go'
    ```
-   Filter by basename to one of: `lifecycle`, `files`, `patch_blocklist`
-   (files that implement `reboot`, `upgrade`, `rollback`, `reset`,
-   `patch_config`, `apply_config`). Exit early with verdict `GO` if the
-   filtered list is empty.
+   Filter by basename to one of: `lifecycle`, `files`, `patch_blocklist`,
+   or any `*_preflight` (files that implement `reboot`, `upgrade`,
+   `rollback`, `reset`, `patch_config`, `apply_config`, or preflight
+   helpers that gate those mutations). Exit early with verdict `GO` if
+   the filtered list is empty.
 
 2. **Load the guard matrix.** Read `references/guard-matrix.md`. Its
    `required_args` and `default_values` columns are the ground truth.
@@ -50,6 +51,13 @@ git rev-parse --verify "${BASE:-origin/main}" >/dev/null \
    - a default literal changed (e.g. `dry_run: true` → `dry_run: false`),
    - a new control-flow path reaches the mutating gRPC call without passing
      through the guard check.
+
+4b. **Preflight helper check.** For any `*_preflight.go` in the filtered
+    set, load `.claude/rules/quorum-member-counting.md` and apply its
+    invariants against the diff (dedup by member `Id` before counting,
+    `map[<id-type>]struct{}` structure, no reliance on
+    `len(msg.GetMembers())`). Flag as regression if a preflight helper
+    is introduced or modified without the dedup pattern.
 
 5. **Emit the report.** Use the exact template below.
 
@@ -81,3 +89,4 @@ Omit rows for tools whose file was not touched.
 ## References
 
 - `references/guard-matrix.md` — guard matrix mirrored verbatim from repo-root `CLAUDE.md` § Safety.
+- `.claude/rules/quorum-member-counting.md` — preflight helper invariants (member-ID dedup, strict-majority rule).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ Mutating tools require explicit guards — missing any of these will error or ca
 - `talos_patch_config` defaults `dry_run=true`; pass `dry_run=false` + `confirm=true` to apply.
 - `talos_apply_config` takes `config_file` (absolute local path to YAML/JSON, max 1 MiB — secrets never enter context). Defaults `dry_run=true`, requires exactly one node. Replaces entire machine config — prefer `talos_patch_config` for targeted changes.
 
+Quorum/member-count invariants for preflight helpers: see `.claude/rules/quorum-member-counting.md` (auto-loaded when editing `internal/tools/etcd_preflight.go` or any `*_preflight.go`).
+
 ### Safety Profile
 
 `TALOS_MCP_SAFETY_PROFILE` seeds four gating flags at startup. Individual env vars override the profile. When the profile var is unset, each flag defaults to its own env var (backwards-compatible).


### PR DESCRIPTION
## What does this PR do?

**Change ID:** `review-knowledge-bake`

Encodes the non-blocking findings from [PR #154's review](https://github.com/Nosmoht/talos-mcp-server/pull/154#pullrequestreview-4119997370) into the repo's Claude Code primitives (rules, skills, agent checklists) so future changes carry the lessons automatically instead of rediscovering them.

Pure docs/primitive change — no Go code, no behaviour change.

### Delivered

- **New rule `.claude/rules/quorum-member-counting.md`** — cluster-member counting for quorum decisions must dedup by raft node `Id` (`uint64` for etcd), never trust `len(msg.GetMembers())`, and document the ID type in the helper's doc comment. Learner caveat noted for future voting-member filters.
- **`CLAUDE.md` cross-reference** — one-line pointer to the new rule, placed after the mutating-tool safety bullets (same convention the existing `release-workflow.md` reference uses under Release).
- **`guard-mutating-tool` skill** — widen Step 1's basename filter to include `*_preflight` so preflight diffs no longer short-circuit the audit, and add Step 4b that loads the new rule and applies its invariants against preflight diffs. Rule listed under References.
- **`add-mcp-tool` skill** — append a "Confirm-guard invariants" section in `references/safety-defaults.md` referencing `internal/tools/invariants_test.go`, the `knownConfirmGapTools` waiver process, and #156 as the canonical waiver example. Append a "Preflight helpers" section pointing at the new rule.
- **Reviewer agents** — `operational-safety-reviewer.md`, `compatibility-reviewer.md`, and `staff-reviewer.md` now point to `internal/tools/register.go` (was `cmd/talos-mcp/main.go`) after the registration extraction in PR #154. `researcher.md` and `security-reviewer.md` intentionally NOT touched — their references are about the HTTP server / historical context, not tool registration.

### Out of scope

No Go code, no test changes, no new tool surface. The canonical implementation (etcd member dedup) already landed in PR #154.

## Checklist

- [x] `make check` passes locally (fmt + vet + lint + test) — verified (no Go changes)
- [x] Commit messages follow conventional commits — `docs(claude): ... [review:review-knowledge-bake]`
- [x] New/changed tools include tests — n/a (no Go changes)
- [x] Documentation updated if applicable — this PR _is_ the documentation update

## Review

`staff-reviewer` artifact at `.claude/reviews/review-knowledge-bake/review.md`: **approved**, no escalations, no findings.

## Related

- Follow-up to #154 (merged) — encodes the five non-blocking findings from that review.
- References #156 (Phase B retrofit of `talos_service_action` confirm gap) as the canonical `knownConfirmGapTools` waiver example in the `add-mcp-tool` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)