### PR TITLE
docs(agents): promote four process rules from local memory to repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,30 @@ work concurrently on this repository via git worktrees. This document defines:
 
 ---
 
+## Agent Tooling
+
+GitHub operations use the `mcp__github__*` MCP tools, not the `gh` CLI. MCP tools are semantically richer, participate in the permission model, and are the intended interface for GitHub in an agent session.
+
+Reserve `gh` CLI for operations without an MCP equivalent:
+
+- `gh pr checks <n>` — CI check-run status
+- `gh auth login` — interactive auth setup
+- `gh run view` — workflow run inspection
+
+Never use `gh` for issues, PRs, reviews, comments, branches, labels, or search when an `mcp__github__*` tool exists. In particular, prefer `mcp__github__pull_request_read` with `method=get` over `gh pr view` for state and merged-at checks.
+
+---
+
+## Planning Discipline
+
+Non-trivial plans must pass `senior-plan-reviewer` **and** one adversarial pass before `ExitPlanMode`. Non-trivial = multi-phase, multi-PR, touches mutating tools, or proposes an architectural change.
+
+- Run the two reviewers in parallel with distinct perspectives: `senior-plan-reviewer` for completeness and architecture; a `general-purpose` or `codex:codex-rescue` agent for adversarial risk surfaces the primary reviewer may endorse by default.
+- Fold every review finding into the plan file, or document why it is accepted as-is. Empirical note: adversarial passes have caught sequencing gaps, skill-filter dead paths, and invalid label taxonomy that the senior reviewer accepted — the two roles are complementary, not redundant.
+- Trivial plans (single-line fix, typo, rename) may `ExitPlanMode` direct.
+
+---
+
 ## Coding Conventions
 
 ### Baseline standards
@@ -379,6 +403,30 @@ git worktree remove .claude/worktrees/<change-id>
 git branch -d feat/<change-id>
 ```
 
+### Follow-up bake PRs
+
+When a review produces both code-level fixes and reusable lessons worth encoding into `.claude/rules/`, `.claude/skills/`, or `.claude/agents/`, split into two PRs:
+
+1. Code-fix PR on the original feature branch.
+2. Bake PR on a fresh branch off `main`, created **only after** the code-fix PR merges.
+
+**Why:** the primitive files reference specific code paths (new helpers, new test invariants, renamed packages). Branching the bake off an open PR leaves the rule or agent checklist pointing at files that do not yet exist on `main`.
+
+Verify the merge gate using an MCP call (not `gh pr view` — see § Agent Tooling):
+
+```
+mcp__github__pull_request_read method=get owner=<owner> repo=<repo> pullNumber=<n>
+→ verify .state == "MERGED" and .mergedAt != null
+```
+
+Then:
+
+```bash
+git worktree add -b feat/<bake-slug> .claude/worktrees/<bake-slug> origin/main
+```
+
+If the review also surfaced **deferred process debt** (a test-suite waiver, a known retrofit, a blocked guard invariant), file a real GitHub issue with valid label taxonomy (`type: chore` or `type: bug`, one `priority:` label, `area:` labels, `needs: triage`) and reference both the merged source PR **and** the tracking issue in the bake commit message and PR body. Test-code comments and `knownXxxGapTools` maps are waivers, not trackers — the tracker goes on GitHub.
+
 ---
 
 ## Review Governance
@@ -399,6 +447,10 @@ cp .claude/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-com
    - `status: escalate` → invoke each listed escalation reviewer
 3. **Escalation** (if needed) — invoke the domain reviewer. Artifact: `.claude/reviews/{change-id}/review-{type}.md`
 4. **Commit** — only once all required artifacts show `status: approved`.
+
+### PR-level review before merge
+
+A PR that lacks an existing GitHub approval must be reviewed by a subagent (typically `staff-reviewer`) before merge. If the review surfaces findings, fix them and re-review until clean. Batch-merge flows do not waive the gate — every PR carries its own review. Commit-time reviews (pre-commit hook) are a separate gate; the merge step itself is manual and relies on this rule.
 
 ### Review depth
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ git worktree add -b feat/<slug> .claude/worktrees/<slug> origin/main
 
 ## Project Management
 
-Issue lifecycle, coding conventions, and multi-agent coordination: [AGENTS.md](./AGENTS.md).
+Issue lifecycle, agent tooling, planning discipline, coding conventions, and multi-agent coordination: [AGENTS.md](./AGENTS.md).
 
 Find ready issues: `repo:Nosmoht/talos-mcp-server is:issue is:open label:"status: ready" sort:created-asc`
 


### PR DESCRIPTION
## What does this PR do?

**Change ID:** `promote-agent-rules`

Four process rules previously lived only in this machine's local auto-memory (`~/.claude/projects/-Users-ntbc-workspace-talos-mcp-server/memory/`). That path is not in the repo, so on a fresh `git clone` — a new laptop, a CI runner, another contributor's agent session — the rules silently vanished. This PR encodes them in `AGENTS.md` so every clone picks them up automatically.

### Rules promoted

1. **Prefer GitHub MCP over `gh` CLI** → new top-level `## Agent Tooling`. MCP tools are semantically richer and participate in the permission model; `gh` is reserved for operations without an MCP equivalent (`gh pr checks`, `gh auth login`, `gh run view`).
2. **Plan review before ExitPlanMode** → new top-level `## Planning Discipline`. Non-trivial plans need `senior-plan-reviewer` + one adversarial pass. Trivial plans may exit direct. Kept out of `## Review Governance` because plan review is a pre-implementation gate without an artefact or hook.
3. **PR-level review before merge** → new `### PR-level review before merge` subsection under existing `## Review Governance`. Batch-merge flows do not waive the gate; the commit-time pre-commit hook is a separate gate.
4. **Follow-up bake PRs wait for source-PR merge** → new `### Follow-up bake PRs` subsection under existing `## Worktree Workflow`. Verifies the merge via `mcp__github__pull_request_read` (not `gh pr view`, per rule #1) and requires a tracking GitHub issue (with valid label taxonomy) for any deferred process debt surfaced by the review.

Also: `CLAUDE.md § Project Management` delegation line extended to name the two new top-level sections so they are indexable from the entry point.

### Why not `.claude/rules/*.md`?

The existing `.claude/rules/` convention (`release-workflow.md`, `quorum-member-counting.md`) is for **file-scoped** invariants auto-loaded when editing specific paths. The four rules here are not file-scoped — they apply to every PR, every plan, every follow-up bake. `AGENTS.md` is always present and already hosts Review Governance + Worktree Workflow.

### Self-apply

This PR follows the rules it adds:

- **Rule #1:** all GitHub operations use `mcp__github__*` — no `gh pr *` in this session.
- **Rule #2:** the plan at `Plans/curious-inventing-spindle.md` passed `senior-plan-reviewer` + adversarial review (four findings folded in: MCP-vs-`gh` self-contradiction resolved, tracking-issue clause restored, Planning Discipline placement fixed, Part 3 scope honest).
- **Rule #3:** `staff-reviewer` artefact at `.claude/reviews/promote-agent-rules/review.md` with `status: approved`, no escalations, no findings.
- **Rule #4:** not applicable — this bake references no code in an open PR; AGENTS.md content stands on already-merged repo state.

## Checklist

- [x] `make check` passes locally — no Go changes, verified
- [x] Commit message follows conventional commits — `docs(agents): ... [review:promote-agent-rules]`
- [x] New/changed tools include tests — n/a (docs only)
- [x] Documentation updated if applicable — this PR *is* the documentation update

## Review

`staff-reviewer` artefact at `.claude/reviews/promote-agent-rules/review.md`: **approved**, no escalations, no findings.

## Related

Follow-up in spirit to #154 and #157 — those two PRs established the review pattern and baked specific lessons into `.claude/rules/quorum-member-counting.md`. This PR extends the same discipline to always-on process rules by putting them in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)