### PR TITLE
fix(tools): add confirm guard to talos_service_action

### DIFF
--- a/.claude/skills/add-mcp-tool/references/safety-defaults.md
+++ b/.claude/skills/add-mcp-tool/references/safety-defaults.md
@@ -23,7 +23,7 @@ Source of truth: repo root `CLAUDE.md` § Safety.
 
 - Every mutating tool MUST carry a `Confirm bool` field in its args struct. Every destructive tool registration MUST carry a `confirm` property in its `InputSchema`.
 - The invariants test runs on every CI build: destructive tools never leak through `readOnly=true` registration, and every destructive tool's schema advertises `confirm`.
-- If a new mutating tool legitimately cannot carry `Confirm` yet (rare — requires justification in the PR description), add it to `knownConfirmGapTools` in `invariants_test.go` **and** file a tracking GitHub issue (`type: chore`, `priority: P2`, `area: tools`, `origin: audit`) referencing the waiver. The `t.Logf` line is not a tracker — missing issues are a process failure. Reference: issue #156 is the canonical example (`talos_service_action` waiver).
+- If a new mutating tool legitimately cannot carry `Confirm` yet (rare — requires justification in the PR description), add it to `knownConfirmGapTools` in `invariants_test.go` **and** file a tracking GitHub issue (`type: chore`, `priority: P2`, `area: tools`, `origin: audit`) referencing the waiver. The `t.Logf` line is not a tracker — missing issues are a process failure. Reference: issue #156 is the canonical historical example of the full protocol lifecycle (waiver added → tracking issue → fix landed → waiver removed). The waiver is no longer active — the example is preserved because it documents every step of the workflow.
 
 ## Preflight helpers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ make check   # full CI parity: fmt + vet + lint + test
 
 Mutating tools require explicit guards — missing any of these will error or cause irreversible cluster damage:
 
-- `talos_reboot`, `talos_upgrade`, `talos_rollback`, `talos_reset` all require `confirm=true` and explicit `nodes`.
+- `talos_reboot`, `talos_upgrade`, `talos_rollback`, `talos_reset` all require `confirm=true` and explicit `nodes`. `talos_service_action` requires `confirm=true` (nodes optional — falls back to talosconfig defaults).
+- `talos_service_action`: restarting `etcd` is not supported by the Talos API — use `talos_reboot` or the `investigate-etcd` prompt instead.
 - `talos_reboot` hits **all listed nodes simultaneously** — specify one at a time to avoid a full outage. Use `wait=true` to block until complete (default timeout `5m`).
 - `talos_upgrade` `preserve` defaults to `true` (keep EPHEMERAL partition) — differs from `talosctl` default of `false`.
 - `talos_reset` `graceful` defaults to `true` (drain workloads, leave etcd). Set `false` only on unresponsive nodes. `system_labels_to_wipe` empty = full disk wipe.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ These tools modify cluster state and have explicit safety guards.
 
 | Tool | Description | Guards |
 |---|---|---|
-| `talos_service_action` | Start, stop, or restart a Talos service (note: restarting `etcd` is not supported by the Talos API). | — |
+| `talos_service_action` | Start, stop, or restart a Talos service (note: restarting `etcd` is not supported by the Talos API). | `confirm=true` required |
 | `talos_reboot` | Reboot target nodes. Supports `mode`: `default`, `powercycle`, `force`. | `confirm=true` required; `nodes` must be explicit |
 | `talos_upgrade` | Upgrade Talos on target nodes. Supports `preserve` (default `true`), `stage`, `force`, `reboot_mode`. | `confirm=true` required; `nodes` and `image` required |
 | `talos_rollback` | Roll back the last upgrade on target nodes. | `confirm=true` required; `nodes` must be explicit |
@@ -232,10 +232,10 @@ MCP Client (Claude Code / Codex)
 |---|---|
 | Read-only mode | `TALOS_MCP_READ_ONLY=true` registers only read-only tools at startup; mutating tools are never exposed to the LLM |
 | Path allowlist | `TALOS_MCP_ALLOWED_PATHS=/etc,/proc` restricts `talos_read_file` and `talos_list_files` to specified prefixes |
-| Confirm gates | `talos_reboot`, `talos_upgrade`, `talos_rollback`, and `talos_patch_config` (when `dry_run=false`) require `confirm=true`; enforced server-side |
+| Confirm gates | Always require `confirm=true`: `talos_service_action`, `talos_reboot`, `talos_upgrade`, `talos_rollback`, `talos_reset`. Require `confirm=true` when `dry_run=false`: `talos_patch_config`, `talos_apply_config`. All enforced server-side. |
 | Preserve default | `talos_upgrade` defaults `preserve` to `true` (keep EPHEMERAL partition) — differs from `talosctl` default of `false` |
 | Dry-run default | `talos_patch_config` defaults to `dry_run=true`; applying requires both `dry_run=false` and `confirm=true` |
-| Audit logging | All mutating tool calls (`talos_service_action`, `talos_reboot`, `talos_upgrade`, `talos_rollback`, `talos_patch_config`) emit a structured log line to stderr: `AUDIT timestamp=<RFC3339> tool=<name> nodes=<list> args=<json>` (patch content is redacted) |
+| Audit logging | All mutating tool calls (`talos_service_action`, `talos_reboot`, `talos_upgrade`, `talos_rollback`, `talos_reset`, `talos_patch_config`, `talos_apply_config`) emit a structured log line to stderr: `AUDIT timestamp=<RFC3339> tool=<name> nodes=<list> args=<json>` (patch content is redacted) |
 
 ### What Is Not in the Threat Model
 

--- a/internal/tools/invariants_test.go
+++ b/internal/tools/invariants_test.go
@@ -41,17 +41,20 @@ func TestInvariant_ReadOnlyGatesDestructiveTools(t *testing.T) {
 	}
 }
 
-// knownConfirmGapTools lists destructive tools that ship today WITHOUT a
-// confirm property in their InputSchema. Each entry is a documented debt:
-// the invariants test allowlists these so CI stays green, while adding a new
-// destructive tool without confirm still fails.
+// knownConfirmGapTools is the waiver registry for destructive tools that
+// legitimately cannot carry a `confirm` property in their InputSchema yet.
+// The map is currently empty — every destructive tool advertises confirm.
 //
-// Phase B of the talos-mcp coverage plan retrofits these tools with confirm
-// + risk_acknowledgements. When that PR lands, the corresponding entry is
-// removed from this map and the test starts enforcing on it.
-var knownConfirmGapTools = map[string]string{
-	"talos_service_action": "Phase B retrofit — add Confirm + RiskAcknowledgements to ServiceActionArgs (tracked in the talos-mcp coverage plan)",
-}
+// To add a waiver: insert `"talos_<name>": "<reason + tracking issue>"`. The
+// invariants test will then `t.Logf` the gap on every CI run instead of failing.
+// File a tracking GitHub issue per
+// .claude/skills/add-mcp-tool/references/safety-defaults.md before adding
+// the entry — the t.Logf line is not a tracker.
+//
+// Issue #156 was the canonical use of this mechanism: talos_service_action
+// shipped without confirm, was waived here, tracked as #156, and retrofitted
+// — at which point the entry was removed.
+var knownConfirmGapTools = map[string]string{}
 
 // TestInvariant_DestructiveToolsRequireConfirm enforces Invariant #2 (partial):
 // every destructive tool's InputSchema must expose a `confirm` property so

--- a/internal/tools/lifecycle.go
+++ b/internal/tools/lifecycle.go
@@ -37,12 +37,17 @@ const (
 type ServiceActionArgs struct {
 	ServiceName string   `json:"service_name" jsonschema:"Name of the service to act on (e.g. 'kubelet'\\, 'containerd'\\, 'etcd')."`
 	Action      string   `json:"action" jsonschema:"Action to perform: 'start'\\, 'stop'\\, or 'restart'."`
+	Confirm     bool     `json:"confirm" jsonschema:"REQUIRED: Must be explicitly set to true to confirm the service action."`
 	Nodes       []string `json:"nodes,omitempty" jsonschema:"Target node IPs or hostnames. Omit to use the default nodes from talosconfig."`
 }
 
 // HandleServiceAction implements the talos_service_action tool.
 func (h *Handlers) HandleServiceAction(ctx context.Context, _ *mcp.CallToolRequest, args ServiceActionArgs) (*mcp.CallToolResult, any, error) {
 	h.auditLog("talos_service_action", args, args.Nodes)
+
+	if !args.Confirm {
+		return nil, nil, fmt.Errorf("service_action refused: confirm must be explicitly set to true")
+	}
 
 	if args.ServiceName == "" {
 		return nil, nil, fmt.Errorf("service_name is required")

--- a/internal/tools/lifecycle_test.go
+++ b/internal/tools/lifecycle_test.go
@@ -102,13 +102,33 @@ func TestHandleUpgrade_Guards(t *testing.T) {
 	}
 }
 
+// TestHandleServiceAction_NoConfirm verifies the confirm guard rejects calls
+// that omit confirm=true, before any other validation runs.
+func TestHandleServiceAction_NoConfirm(t *testing.T) {
+	h := safeH()
+	ctx := context.Background()
+
+	_, _, err := h.HandleServiceAction(ctx, nil, ServiceActionArgs{
+		ServiceName: "kubelet",
+		Action:      "restart",
+		Confirm:     false,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing confirm, got nil")
+	}
+	if !strings.Contains(err.Error(), "confirm must be explicitly set to true") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 // TestHandleServiceAction_EmptyServiceName verifies empty service name is rejected.
 func TestHandleServiceAction_EmptyServiceName(t *testing.T) {
 	h := safeH()
 	ctx := context.Background()
 
 	_, _, err := h.HandleServiceAction(ctx, nil, ServiceActionArgs{
-		Action: "restart",
+		Action:  "restart",
+		Confirm: true,
 	})
 	if err == nil {
 		t.Fatal("expected error for empty service_name, got nil")
@@ -126,6 +146,7 @@ func TestHandleServiceAction_InvalidAction(t *testing.T) {
 	_, _, err := h.HandleServiceAction(ctx, nil, ServiceActionArgs{
 		ServiceName: "kubelet",
 		Action:      "obliterate",
+		Confirm:     true,
 	})
 	if err == nil {
 		t.Fatal("expected error for unknown action, got nil")

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -139,6 +139,7 @@ func Register(server *mcp.Server, h *Handlers, readOnly bool) {
 		mcp.AddTool(server, &mcp.Tool{
 			Name: "talos_service_action",
 			Description: "Start, stop, or restart a Talos service on the target nodes. " +
+				"Requires confirm=true. " +
 				"NOTE: restarting 'etcd' is not supported by the Talos API and will return an error; " +
 				"use talos_reboot or the investigate-etcd prompt to recover etcd.",
 			Annotations: &mcp.ToolAnnotations{DestructiveHint: destructive, OpenWorldHint: closedWorld},


### PR DESCRIPTION
## What does this PR do?

Closes #156

**Change ID:** service-action-confirm-guard

`talos_service_action` was the only mutating tool that shipped without a `confirm=true` safety gate, breaking the contract documented in `CLAUDE.md` § Safety. The invariants test waived it via `knownConfirmGapTools` as documented Phase B debt; this PR closes the waiver.

- Adds `Confirm bool` to `ServiceActionArgs` and rejects calls that omit `confirm=true` at the top of `HandleServiceAction` (after `auditLog` so refused attempts are still recorded; before all other validation so a missing confirm always wins).
- Empties `knownConfirmGapTools` so `TestInvariant_DestructiveToolsRequireConfirm/talos_service_action` actively asserts the schema property is present (was previously `t.Logf`-waived).
- Updates `CLAUDE.md`, `README.md`, the tool description string in `register.go`, and the `add-mcp-tool` safety-defaults reference. Closes a pre-existing `talos_reset` / `talos_apply_config` gap in the README Confirm-gates and Audit-logging rows while we're touching them.

**Behavior change:** callers that previously invoked `talos_service_action` without `confirm=true` now receive `service_action refused: confirm must be explicitly set to true` — same refusal pattern every other mutating tool already enforces.

## Checklist

- [x] `make check` passes locally (fmt + vet + lint + test)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] New/changed tools include tests (`TestHandleServiceAction_NoConfirm` added; existing service-action tests updated with `Confirm: true`)
- [x] Documentation updated if applicable (`CLAUDE.md`, `README.md`, `register.go` description, safety-defaults reference)