### PR TITLE
fix(release): use RELEASE_APP token for changelog-pr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,14 +161,25 @@ jobs:
   # main and the just-published npm tarball. Commits go through the Contents
   # API, which produces web-flow-signed commits — required because branch
   # protection on main sets required_signatures: true. A plain `git push` with
-  # GITHUB_TOKEN would be rejected as unsigned.
+  # GITHUB_TOKEN would be rejected as unsigned. The `gh pr create` call uses the
+  # RELEASE_APP installation token rather than the default GITHUB_TOKEN because
+  # repo policy sets can_approve_pull_request_reviews: false, which also blocks
+  # PR creation by the default token. The RELEASE_APP token already drives
+  # auto-tag.yml and bypasses that restriction; it must carry pull_requests:write
+  # and contents:write on this repo.
   changelog-pr:
     needs: mcp-registry-publish
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           fetch-depth: 0
@@ -179,7 +190,7 @@ jobs:
 
       - name: Open PR with updated CHANGELOG
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What does this PR do?

**Change ID:** changelog-pr-app-token

Closes the gap surfaced by the v2.3.3 release: the new `changelog-pr` job failed with

> \`pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)\`

The repo has `can_approve_pull_request_reviews: false` (verified via `GET /repos/.../actions/permissions/workflow`), which — despite the name — blocks the default `GITHUB_TOKEN` from **both** approving reviews and creating PRs. The signed Contents-API commit had already succeeded; only the `gh pr create` call was rejected. PR #161 was opened manually to unblock v2.3.3.

This PR switches the job to the existing `RELEASE_APP` installation token (same pattern as `auto-tag.yml`, pinned to the same `create-github-app-token` SHA). App tokens bypass the restriction. The job's default-token permissions drop from `contents: write` / `pull-requests: write` to `contents: read` / `pull-requests: read` — the default token now only serves the checkout step; everything else routes through `env.GH_TOKEN` from the app.

## Prerequisite

The `RELEASE_APP` installation must carry these permissions on the repo:
- `contents: write` — already required for `auto-tag.yml`
- `pull_requests: write` — **new**; may need a one-time update in the App's GitHub settings

If missing, the next release will fail at the same step with a 403. Fixable without any code change by updating the App's permission set.

## Checklist

- [x] `staff-reviewer` review: `approved` (one minor non-blocking suggestion recorded — tighten `pull-requests: read` → `none`; left as-is)
- [x] Commit message scoped and conventional with `[review:changelog-pr-app-token]` tag
- [x] No Go changes — `make check` not re-run
- [x] No new workflow dependencies; app-token action SHA already in use by three other workflows

## Verification plan

- [ ] Merge this PR
- [ ] Cut the next release tag (via auto-tag or manual) — observe `changelog-pr` succeeds and opens `chore/changelog-v<version>` PR automatically
- [ ] If `gh pr create` still fails with 403, add `pull_requests: write` to the RELEASE_APP permissions and re-run the job