### PR TITLE
chore(safety): gitignore mcpregistry token files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 node_modules/
 .env
 .envrc
+.mcpregistry_*_token
 coverage.out
 .claire/
 .claude/worktrees/


### PR DESCRIPTION
## What does this PR do?

**Change ID:** gitignore-secret-tokens

Adds `.mcpregistry_*_token` to `.gitignore` to prevent accidental commit of MCP registry authentication tokens that the `mcpregistry` CLI creates in the repo root.

## Checklist

- [x] `make check` passes locally (fmt + vet + lint + test)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] New/changed tools include tests — N/A (`.gitignore` only)
- [x] Documentation updated if applicable — N/A