### PR TITLE
fix(http): restore cross-origin protection default after go-sdk v1.6.0 bump

### DIFF
--- a/cmd/talos-mcp/main.go
+++ b/cmd/talos-mcp/main.go
@@ -302,10 +302,17 @@ func runServer(ctx context.Context, server *mcp.Server, addr, token string, hc h
 
 	// HTTP mode — DisableLocalhostProtection allows proxied requests whose Host
 	// header differs from the bind address (e.g. behind nginx/Caddy/Tailscale).
+	// CrossOriginProtection is set explicitly because go-sdk v1.6.0 no longer
+	// enables the zero-value http.CrossOriginProtection by default when the
+	// field is nil. The zero value rejects non-safe (POST/PUT/PATCH/DELETE)
+	// cross-origin browser requests via Sec-Fetch-Site / Origin-vs-Host checks
+	// — orthogonal to DisableLocalhostProtection (which targets DNS rebinding
+	// at the Host-header layer).
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
 		return server
 	}, &mcp.StreamableHTTPOptions{
 		DisableLocalhostProtection: true,
+		CrossOriginProtection:      &http.CrossOriginProtection{},
 		Logger:                     slog.Default(),
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.3
 require (
 	github.com/cosi-project/runtime v1.14.1
 	github.com/google/jsonschema-go v0.4.3
-	github.com/modelcontextprotocol/go-sdk v1.5.0
+	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/siderolabs/talos/pkg/machinery v1.12.6
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/mdlayher/netlink v1.8.0 h1:e7XNIYJKD7hUct3Px04RuIGJbBxy1/c4nX7D5Yyvvl
 github.com/mdlayher/netlink v1.8.0/go.mod h1:UhgKXUlDQhzb09DrCl2GuRNEglHmhYoWAHid9HK3594=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
-github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
-github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
+github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
+github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/onsi/ginkgo/v2 v2.20.1 h1:YlVIbqct+ZmnEph770q9Q7NVAz4wwIiVNahee6JyUzo=
 github.com/onsi/ginkgo/v2 v2.20.1/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=


### PR DESCRIPTION
## Summary

- Bumps `github.com/modelcontextprotocol/go-sdk` v1.5.0 → v1.6.0 (supersedes #169).
- Explicitly sets `StreamableHTTPOptions.CrossOriginProtection: &http.CrossOriginProtection{}` in `cmd/talos-mcp/main.go` to restore the v1.4.1–v1.5.0 default that v1.6.0 dropped.

## Why this matters

go-sdk v1.6.0 changes a security default. When `CrossOriginProtection` is nil, the SDK no longer applies a zero-value `*http.CrossOriginProtection` (previously implicit). The zero value rejects non-safe (POST/PUT/PATCH/DELETE) cross-origin browser requests via `Sec-Fetch-Site` / `Origin`-vs-`Host` checks — a defense-in-depth layer on top of bearer-token auth that guards against CSRF abuse when a token leaks into a malicious browser tab.

Restoring this via an explicit field assignment (rather than via the SDK's `MCPGODEBUG=enableoriginverification=1` compatibility flag) is preferred because (a) it survives env-stripping deployments, (b) it is visible at the call site, (c) the env shim is removed in SDK v1.8.0.

Cross-origin protection is orthogonal to the existing `DisableLocalhostProtection: true` setting, which targets DNS rebinding at the Host-header layer.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages green (httptest + http.DefaultClient is same-origin, so green/red is unaffected)
- [ ] manual smoke test: HTTP transport accepts MCP POST from Claude Code / MCP Inspector (no `Sec-Fetch-Site` header set by these clients → admitted)
- [ ] manual adversarial test: cross-origin POST with `Origin: https://evil.example` and `Sec-Fetch-Site: cross-site` is rejected with 403

## Follow-ups (not in this PR)

1. Add CSRF regression test for HTTP transport (cross-origin POST → 403). Tracked as a separate issue.
2. Migrate from the `Deprecated` `StreamableHTTPOptions.CrossOriginProtection` field to the `protection.Handler(mcpHandler)` wrapper before SDK v1.8.0.

## References

- [go-sdk v1.6.0 release notes](https://github.com/modelcontextprotocol/go-sdk/releases/tag/v1.6.0) — "Cross-Origin Protection Default Change"
- [`net/http.CrossOriginProtection`](https://pkg.go.dev/net/http#CrossOriginProtection) — Go 1.25+ stdlib API

🤖 Generated with [Claude Code](https://claude.com/claude-code)