### PR TITLE
chore(http): migrate off deprecated CrossOriginProtection field

### DIFF
--- a/cmd/talos-mcp/main.go
+++ b/cmd/talos-mcp/main.go
@@ -299,17 +299,33 @@ func buildHTTPMux(mcpHandler http.Handler, token string, hc httpTransportConfig,
 // DisableLocalhostProtection allows proxied requests whose Host header differs from
 // the bind address (e.g. behind nginx/Caddy/Tailscale).
 //
-// CrossOriginProtection is set explicitly because go-sdk v1.6.0 no longer enables
-// the zero-value http.CrossOriginProtection by default when the field is nil. The
-// zero value rejects non-safe (POST/PUT/PATCH/DELETE) cross-origin browser requests
-// via Sec-Fetch-Site / Origin-vs-Host checks — orthogonal to DisableLocalhostProtection
-// (which targets DNS rebinding at the Host-header layer).
+// Cross-origin protection is intentionally NOT set on this struct. go-sdk v1.6.0
+// deprecated the StreamableHTTPOptions.CrossOriginProtection field and v1.8.0 removes
+// it; the SDK directs callers to wrap the handler with the stdlib middleware instead.
+// newProtectedMCPHandler applies that wrapper. The cross-origin layer is orthogonal
+// to DisableLocalhostProtection (cross-origin non-safe-method denial vs. DNS rebinding
+// at the Host-header layer).
 func newStreamableHTTPOptions(logger *slog.Logger) *mcp.StreamableHTTPOptions {
 	return &mcp.StreamableHTTPOptions{
 		DisableLocalhostProtection: true,
-		CrossOriginProtection:      &http.CrossOriginProtection{},
 		Logger:                     logger,
 	}
+}
+
+// newProtectedMCPHandler wires the streamable HTTP handler together with the
+// stdlib cross-origin protection middleware. Consolidating both steps here
+// removes drift between production (runServer) and tests (buildTestHandler,
+// buildMuxForTest) — the same drift class that motivated newStreamableHTTPOptions.
+// See PR #177 and issue #179 for the regression this guards against.
+//
+// The wrapper form replaces the deprecated StreamableHTTPOptions.CrossOriginProtection
+// field (go-sdk v1.6.0 deprecation; v1.8.0 removal). Source-compatible with v1.6.x.
+func newProtectedMCPHandler(server *mcp.Server, logger *slog.Logger) http.Handler {
+	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+		return server
+	}, newStreamableHTTPOptions(logger))
+	protection := http.NewCrossOriginProtection()
+	return protection.Handler(mcpHandler)
 }
 
 // runServer starts the server in either stdio or HTTP mode.
@@ -321,13 +337,11 @@ func runServer(ctx context.Context, server *mcp.Server, addr, token string, hc h
 		return server.Run(ctx, &mcp.StdioTransport{})
 	}
 
-	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
-		return server
-	}, newStreamableHTTPOptions(slog.Default()))
+	protectedHandler := newProtectedMCPHandler(server, slog.Default())
 
 	httpSrv := &http.Server{
 		Addr:              addr,
-		Handler:           buildHTTPMux(mcpHandler, token, hc, healthProbe),
+		Handler:           buildHTTPMux(protectedHandler, token, hc, healthProbe),
 		ReadHeaderTimeout: 30 * time.Second,
 	}
 

--- a/cmd/talos-mcp/main_test.go
+++ b/cmd/talos-mcp/main_test.go
@@ -79,10 +79,8 @@ func TestBuildTokenVerifier(t *testing.T) {
 // security defaults (see issue #179 + PR #177).
 func buildTestHandler(secret string, hc httpTransportConfig) http.Handler {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
-	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
-		return server
-	}, newStreamableHTTPOptions(slog.Default()))
-	return buildHTTPMux(mcpHandler, secret, hc, func(_ context.Context) error { return nil })
+	protectedHandler := newProtectedMCPHandler(server, slog.Default())
+	return buildHTTPMux(protectedHandler, secret, hc, func(_ context.Context) error { return nil })
 }
 
 func TestHTTPHandler_Integration(t *testing.T) {
@@ -151,10 +149,8 @@ func TestHTTPHandler_RateLimit_Integration(t *testing.T) {
 
 func buildMuxForTest(probe func(context.Context) error) (*httptest.Server, func()) {
 	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
-	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
-		return srv
-	}, newStreamableHTTPOptions(slog.Default()))
-	ts := httptest.NewServer(buildHTTPMux(mcpHandler, "secret", newHTTPTransportConfig(), probe))
+	protectedHandler := newProtectedMCPHandler(srv, slog.Default())
+	ts := httptest.NewServer(buildHTTPMux(protectedHandler, "secret", newHTTPTransportConfig(), probe))
 	return ts, ts.Close
 }
 
@@ -258,17 +254,19 @@ func TestHealthzEndpoint(t *testing.T) {
 // SDK's zero-value http.CrossOriginProtection stops denying cross-origin non-safe
 // requests, this test fires. See issue #179.
 //
-// The test fixture goes through buildTestHandler → newStreamableHTTPOptions, the
-// same code path runServer uses in production. A regression that removes
-// CrossOriginProtection from the helper trips the assertions here; a regression
-// that inlines a divergent literal back into runServer is not caught by this
-// test (residual risk documented in #179's plan).
+// The test fixture goes through buildTestHandler → newProtectedMCPHandler →
+// newStreamableHTTPOptions, the same code path runServer uses in production.
+// A regression that removes the cross-origin wrapper from the helper trips the
+// assertions here; a regression that inlines a divergent handler construction
+// back into runServer is not caught by this test (residual risk documented in
+// #179's plan).
 func TestHTTPHandler_CrossOriginProtection_Integration(t *testing.T) {
 	const secret = "csrf-test-token" //nolint:gosec // G101 false positive: test-only bearer token, never reaches production
 
 	// Compile-time binding: the test depends on the shared helper. If
-	// newStreamableHTTPOptions is renamed or removed, this stops compiling.
-	_ = newStreamableHTTPOptions
+	// newProtectedMCPHandler (or transitively newStreamableHTTPOptions) is
+	// renamed or removed, this stops compiling.
+	_ = newProtectedMCPHandler
 
 	hc := newHTTPTransportConfig()
 	ts := httptest.NewServer(buildTestHandler(secret, hc))


### PR DESCRIPTION
## What does this PR do?

Closes #180

**Change ID:** migrate-cross-origin-wrapper

Replaces the struct-literal `StreamableHTTPOptions.CrossOriginProtection` assignment with the documented wrapper form `http.NewCrossOriginProtection().Handler(mcpHandler)` so the HTTP transport keeps compiling after go-sdk v1.8.0 removes the field.

Source-compatible with go-sdk v1.6.x. Semantically a no-op: at go-sdk v1.6.0 source level (`mcp/streamable.go:228-235`), the deprecated field path internally executes `h.opts.CrossOriginProtection.Handler(...)` — wrapping the handler ourselves one layer up is the same chain.

### Diff summary

- `cmd/talos-mcp/main.go` — added helper `newProtectedMCPHandler(server, logger)` that combines `NewStreamableHTTPHandler` + `http.NewCrossOriginProtection().Handler(...)`; removed `CrossOriginProtection: &http.CrossOriginProtection{}` from `newStreamableHTTPOptions`; rewrote the doc comment to describe the wrapper form and the orthogonality vs. `DisableLocalhostProtection`; updated `runServer` to route through the helper.
- `cmd/talos-mcp/main_test.go` — routed `buildTestHandler` and `buildMuxForTest` through the new helper; updated compile-time binding to `_ = newProtectedMCPHandler` (transitively still catches drift on `newStreamableHTTPOptions`); refreshed the CSRF regression-test doc comment to reflect the new call chain.

### Acceptance criteria (from issue body)

| AC  | Predicate | Result |
|-----|-----------|--------|
| AC1 | `grep -nE 'CrossOriginProtection:[[:space:]]' cmd/talos-mcp/main.go` | 0 matches |
| AC2 | `grep -nE '\.Handler\(mcpHandler\)' cmd/talos-mcp/main.go` | 1 match (line 328) |
| AC3 | `grep -nE 'NewCrossOriginProtection\(' cmd/talos-mcp/main.go` | 1 match (line 327) |
| AC4 | `go build ./...` | exit 0 |
| AC5 | `go test ./...` | all packages PASS |
| AC6 | `go test ./cmd/talos-mcp/... -run 'CrossOrigin\|CSRF' -v` | 6/6 sub-tests PASS |
| AC7 | doc comment cites wrapper form + orthogonality to `DisableLocalhostProtection` | verified at `main.go:302-307` |

### Boundaries respected

- ALWAYS: wrapper applied **before** `buildHTTPMux` / `http.Server.Handler` at all three call sites.
- ALWAYS: `DisableLocalhostProtection: true` preserved (orthogonal control).
- NEVER: no `AddTrustedOrigin(...)`, no `go.mod` change, no stdio-mode change, no auth/credential modification.

## Checklist

- [x] `make check` passes locally (fmt + vet + lint + test)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] New/changed tools include tests (existing CSRF regression test from PR #178 covers the runtime behavior)
- [x] Documentation updated if applicable (doc comments on `newStreamableHTTPOptions` and the new `newProtectedMCPHandler` helper)

---

Refs: https://github.com/modelcontextprotocol/go-sdk/blob/v1.6.0/mcp/streamable.go#L98-L102

🤖 Generated with [Claude Code](https://claude.com/claude-code)