### PR TITLE
docs(install): document npm-global install path, operator-upgrade workflow, post-merge release pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,28 @@ work concurrently on this repository via git worktrees. This document defines:
 
 ---
 
+## Operator install / upgrade
+
+The **maintainer-as-operator** persona — a contributor running their own MCP server locally and wanting the latest merged change live in their MCP client — uses the global npm install path:
+
+```bash
+# After your change merges to main and the auto-tag → release pipeline publishes the new version:
+npm install -g talos-mcp@latest
+talos-mcp --version    # verify the commit hash matches HEAD on origin/main
+```
+
+Discovery commands if the install path is unclear on a given machine:
+
+```bash
+which talos-mcp                     # e.g. /opt/homebrew/bin/talos-mcp (macOS, npm-global)
+readlink $(which talos-mcp)         # symlink target → npm-prefix/lib/node_modules/talos-mcp/bin/run.js
+npm list -g talos-mcp               # currently installed version
+```
+
+Full distribution-side docs (npx / binary / build-from-source variants) live in [README.md § Installation](./README.md#installation). The auto-publish mechanism that makes `@latest` meaningful within minutes of a merge is in [CONTRIBUTING.md § Post-merge release pipeline](./CONTRIBUTING.md#post-merge-release-pipeline).
+
+---
+
 ## Agent Tooling
 
 GitHub operations use the `mcp__github__*` MCP tools, not the `gh` CLI. MCP tools are semantically richer, participate in the permission model, and are the intended interface for GitHub in an agent session.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,16 @@ Angular's guidelines do not formally include `chore:` and the boundary between `
 
 Anti-pattern, for clarity: `95a9161 chore(http): migrate off deprecated CrossOriginProtection field` modifies `cmd/talos-mcp/main.go` — under this rule, that commit would be `refactor(http):` (no release in either case, so no retroactive correction; cited only as a forward-looking example).
 
+### Post-merge release pipeline
+
+Every merge to `main` whose commit type triggers a version bump (`feat:` → MINOR, `fix:` → PATCH, `perf:` → PATCH, any `!`-marked or `BREAKING CHANGE:`-footer → MAJOR) drives an automatic release — *provided the commit touched server-relevant paths* (`*.go`, `cmd/**`, `internal/**`, `go.mod`, `go.sum`, `Makefile`, `.goreleaser.yaml`, `server.json`; see `.github/workflows/auto-tag.yml` for the canonical path filter):
+
+1. `auto-tag.yml` inspects the pushed commit's conventional-commit type via `mathieudutour/github-tag-action` and pushes a `v<next>` tag to the repo (no intermediate release PR).
+2. The `v*` tag triggers `release.yml`, which runs `goreleaser` (binary artifacts + provenance attestations + a GitHub Release) and then `npm publish --provenance` via OIDC Trusted Publishing (no long-lived npm tokens; see `.claude/rules/release-workflow.md` for OIDC gotchas).
+3. Operators upgrade via `npm install -g talos-mcp@latest` once the npm-publish job succeeds.
+
+`docs:` / `chore:` / `refactor:` / `test:` / `ci:` / `build:` / `style:` / `revert:` merges do **not** trigger a release (the type is excluded from version bumps and/or the touched paths fall outside the auto-tag filter). The full type → release-impact table is above.
+
 ## Pull requests
 
 1. Fork the repo and create a branch from `main`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ Connects to your cluster via the native Talos gRPC API using the same mTLS crede
 npx talos-mcp
 ```
 
+**Via npm (global install)** for persistent invocation from `$PATH`:
+
+```bash
+npm install -g talos-mcp
+```
+
+Installs the binary as `<npm-prefix>/bin/talos-mcp`. Verify with:
+
+```bash
+which talos-mcp        # path
+talos-mcp --version    # version + commit hash
+npm list -g talos-mcp  # npm's view of the installed version
+```
+
+Upgrade to the latest published release:
+
+```bash
+npm install -g talos-mcp@latest
+```
+
+New releases appear on npmjs.com within minutes of every `feat:` / `fix:` / `perf:` (or breaking) merge to `main` — see [CONTRIBUTING.md § Post-merge release pipeline](./CONTRIBUTING.md#post-merge-release-pipeline) for the mechanism.
+
 **Download binary** (Linux/macOS, amd64/arm64):
 
 Download the latest release from [GitHub Releases](https://github.com/Nosmoht/talos-mcp-server/releases), extract, and place the binary in your `$PATH`.


### PR DESCRIPTION
## What does this PR do?

**Change ID:** operator-install-gaps

Closes the documentation gap surfaced while upgrading the local talos-mcp install: determining how the binary was actually installed on the operator's machine took five exploratory shell calls (`which`, `brew info`, `brew list`, `readlink`, `npm list -g`) because the durable install path was nowhere documented. After this PR, three Repo-tracked files answer the operator-install and release-pipeline questions self-sufficiently.

**Three additive insertions, no deletions, no code touched:**

- `README.md § Installation` — new `**Via npm (global install)**` subsection between the existing `npx talos-mcp` block and the binary-download block. Documents `npm install -g talos-mcp`, the verify-version triplet (`which` / `talos-mcp --version` / `npm list -g`), and the upgrade command. Cross-references CONTRIBUTING § Post-merge release pipeline.

- `AGENTS.md` — new `## Operator install / upgrade` section after `## Overview`. Describes the **maintainer-as-operator** persona (a contributor running their own MCP server locally and wanting their just-merged change live) and lists the install-path-discovery commands. Cross-references README + CONTRIBUTING.

- `CONTRIBUTING.md § Commit messages` — new `### Post-merge release pipeline` subsection describing the actual mechanism: `auto-tag.yml` uses `mathieudutour/github-tag-action` to push `v*` tags on Go-relevant commits, then `release.yml` fires on the tag (goreleaser + `npm publish --provenance` via OIDC Trusted Publishing). The path-filter list and excluded commit types both match the workflow source verbatim.

## Why this is docs-only and `docs:` typed

No Go code, no `go.mod` / `go.sum`, no `release.yml`, no `package.json`, no `release-please-manifest.json` (this repo doesn't use release-please). Per `CONTRIBUTING.md § Local rule — chore: vs refactor:`: "Documentation-only changes are `docs:` regardless of file location." `docs:` has no release impact.

## Review

Two reviewer rounds:

1. **R1 (docs-mode)** — caught a critical factual error in the original draft: the text claimed the repo uses `release-please`, but the actual pipeline uses `mathieudutour/github-tag-action`. Rewrote `CONTRIBUTING.md` and `AGENTS.md` accordingly.
2. **R2 (verification)** — confirmed the corrected text matches `.github/workflows/auto-tag.yml` and `.github/workflows/release.yml` verbatim (mechanism, path filter, excluded commit types).

Local review artifact: `.claude/reviews/operator-install-gaps/review.md` (status: approved, escalations: none).

Plan file: `Plans/feature-request-support-all-zippy-fiddle.md`.

## Checklist

- [x] `make check` passes locally (docs-only, but verified for guardrail)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) — `docs(install): ... [review:operator-install-gaps]`
- [x] New/changed tools include tests — N/A (docs-only)
- [x] Documentation updated if applicable — this PR *is* the documentation