### PR TITLE
fix(tools): document path allowlist symlink limitation and warn at startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Mutating tools require explicit guards — missing any of these will error or ca
 - `talos_reset` `graceful` defaults to `true` (drain workloads, leave etcd). Set `false` only on unresponsive nodes. `system_labels_to_wipe` empty = full disk wipe.
 - `talos_patch_config` defaults `dry_run=true`; pass `dry_run=false` + `confirm=true` to apply.
 - `talos_apply_config` takes `config_file` (absolute local path to YAML/JSON, max 1 MiB — secrets never enter context). Defaults `dry_run=true`, requires exactly one node. Replaces entire machine config — prefer `talos_patch_config` for targeted changes.
+- `talos_read_file` / `talos_list_files`: the `TALOS_MCP_ALLOWED_PATHS` prefix allowlist is defense-in-depth only. The check runs on the MCP server host and does not resolve symlinks on the remote node — a symlink under an allowed prefix pointing elsewhere is not detected (symlinks are resolved on the node, outside the check's view). Do not rely on it as the sole access control.
 
 Quorum/member-count invariants for preflight helpers: see `.claude/rules/quorum-member-counting.md` (auto-loaded when editing `internal/tools/etcd_preflight.go` or any `*_preflight.go`).
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Reads `~/.talos/config` by default (the same file `talosctl` uses). Override via
 | `TALOS_MCP_HTTP_ADDR` | (unset) | If set (e.g. `:8080`), serve Streamable HTTP instead of stdio |
 | `TALOS_MCP_AUTH_TOKEN` | (unset) | Required bearer token when HTTP mode is active |
 | `TALOS_MCP_ALLOWED_NODES` | (unset) | Comma-separated IPs, hostnames, and CIDR ranges permitted as tool targets. Unset allows all. |
-| `TALOS_MCP_ALLOWED_PATHS` | *(all)* | Comma-separated path prefixes allowed for `talos_read_file` and `talos_list_files` (e.g. `/etc,/proc`) |
+| `TALOS_MCP_ALLOWED_PATHS` | *(all)* | Comma-separated path prefixes allowed for `talos_read_file` and `talos_list_files` (e.g. `/etc,/proc`). Defense-in-depth only — checks run on the MCP server host and do **not** resolve symlinks on the remote Talos node, so a symlink under an allowed prefix that points elsewhere is not detected. |
 | `TALOS_MCP_SKIP_VERSION_CHECK` | `false` | Set to `true` to bypass upgrade path validation (e.g. for factory images or custom tags) |
 | `TALOS_MCP_ENABLE_INSECURE` | `false` | Unlock `insecure=true` on `talos_apply_config` / `talos_get` / `talos_version` / `talos_meta`. Bypasses mTLS — REQUIRES `TALOS_MCP_INSECURE_ALLOWED_NODES`. |
 | `TALOS_MCP_INSECURE_ALLOWED_NODES` | (unset) | Comma-separated IPs / CIDRs permitted as maintenance-mode endpoints. Required when `TALOS_MCP_ENABLE_INSECURE=true`. Refused: `0.0.0.0/0`, `::/0`, IPv4 mask `<16`, IPv6 mask `<48`. |
@@ -272,7 +272,7 @@ MCP Client (Claude Code / Codex)
 | Mechanism | How it works |
 |---|---|
 | Read-only mode | `TALOS_MCP_READ_ONLY=true` registers only read-only tools at startup; mutating tools are never exposed to the LLM |
-| Path allowlist | `TALOS_MCP_ALLOWED_PATHS=/etc,/proc` restricts `talos_read_file` and `talos_list_files` to specified prefixes |
+| Path allowlist | `TALOS_MCP_ALLOWED_PATHS=/etc,/proc` restricts `talos_read_file` and `talos_list_files` to specified prefixes. **Defense-in-depth, not a hard boundary:** the check is local to the MCP server — symlinks on the remote Talos node that resolve outside an allowed prefix are not detected. |
 | Confirm gates | Always require `confirm=true`: `talos_service_action`, `talos_reboot`, `talos_upgrade`, `talos_rollback`, `talos_reset`. Require `confirm=true` when `dry_run=false`: `talos_patch_config`, `talos_apply_config`. All enforced server-side. |
 | Preserve default | `talos_upgrade` defaults `preserve` to `true` (keep EPHEMERAL partition) — differs from `talosctl` default of `false` |
 | Dry-run default | `talos_patch_config` defaults to `dry_run=true`; applying requires both `dry_run=false` and `confirm=true` |

--- a/cmd/talos-mcp/main.go
+++ b/cmd/talos-mcp/main.go
@@ -186,6 +186,7 @@ func main() {
 
 	if len(allowedPaths) > 0 {
 		slog.Info("path allowlist active", "entries", len(allowedPaths)) //nolint:gosec // G706: entry count is an integer, not user-controlled string input
+		slog.Warn("path allowlist is defense-in-depth only: the prefix check runs on the MCP server host and does not resolve symlinks on the remote node, so a symlink under an allowed prefix that points elsewhere is not detected")
 	} else {
 		slog.Info("path allowlist disabled")
 	}

--- a/internal/tools/files.go
+++ b/internal/tools/files.go
@@ -60,14 +60,14 @@ func ReadFileOutputSchema() *jsonschema.Schema { return readFileOutputSchema }
 
 // ListFilesArgs defines input for talos_list_files.
 type ListFilesArgs struct {
-	Path    string   `json:"path" jsonschema:"Absolute path on the node to list (e.g. '/etc'\\, '/var/log')."`
+	Path    string   `json:"path" jsonschema:"Absolute path on the node to list (e.g. '/etc'\\, '/var/log'). When TALOS_MCP_ALLOWED_PATHS is set the prefix is enforced as defense-in-depth only; symlinks on the node are not resolved against the allowlist."`
 	Recurse bool     `json:"recurse,omitempty" jsonschema:"Recursively list subdirectories. Defaults to false."`
 	Nodes   []string `json:"nodes,omitempty" jsonschema:"Target node IPs or hostnames. Omit to use the default nodes from talosconfig."`
 }
 
 // ReadFileArgs defines input for talos_read_file.
 type ReadFileArgs struct {
-	Path     string   `json:"path" jsonschema:"Absolute path to the file on the node to read (e.g. '/etc/os-release')."`
+	Path     string   `json:"path" jsonschema:"Absolute path to the file on the node to read (e.g. '/etc/os-release'). When TALOS_MCP_ALLOWED_PATHS is set the prefix is enforced as defense-in-depth only; symlinks on the node are not resolved against the allowlist."`
 	MaxBytes int      `json:"max_bytes,omitempty" jsonschema:"Maximum number of bytes to return. Defaults to 32768 (32KB)."`
 	Nodes    []string `json:"nodes,omitempty" jsonschema:"Target node IPs or hostnames. Omit to use the default nodes from talosconfig."`
 }
@@ -262,6 +262,12 @@ func ParseAllowedPaths(raw string) []string {
 // It returns nil when allowed is empty (no allowlist configured).
 // Prefix matching is directory-boundary-safe: "/etc" does not match "/etc-evil".
 // The path is canonicalized via filepath.Clean to prevent ".." traversal bypass.
+//
+// Limitation: this check runs on the MCP server host against the requested path.
+// It does NOT resolve symlinks on the remote Talos node — a request for a path
+// under an allowed prefix that is a symlink to a target outside the allowlist
+// still passes (the symlink is resolved on the node, outside this check's view).
+// Treat the allowlist as defense-in-depth, not a hard security boundary. See issue #42.
 func checkPathAllowed(rawPath string, allowed []string) error {
 	if len(allowed) == 0 {
 		return nil


### PR DESCRIPTION
## Summary

`TALOS_MCP_ALLOWED_PATHS` prefix checks run on the MCP server host and do **not** resolve symlinks on the remote Talos node — a symlink under an allowed prefix that points elsewhere is not detected. This is inherent to client-side validation of a remote filesystem: the Talos `ReadRequest` carries no symlink metadata, so inline resolution at read time is infeasible.

Scope is **documentation + startup warning** (server-side enforcement deliberately out of scope per the API limitation above).

## Changes

- README env-var table + security-mechanisms table document the limitation
- CLAUDE.md §Safety documents it
- `talos_read_file` / `talos_list_files` tool input descriptions document it
- `checkPathAllowed` doc comment documents it (enforcement logic unchanged)
- Startup `slog.Warn` when the allowlist is active, co-located with the existing allowlist log

## Verification

`make check` (fmt + vet + lint + test) — exit 0. Independent reviewer: APPROVE (5/5 ACs, 0 CRITICAL/HIGH/MEDIUM).

Closes #42
Refs #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)