### PR TITLE
fix(deps): bump go toolchain to 1.26.4 (GO-2026-5037, GO-2026-5039)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Nosmoht/talos-mcp-server
 
 go 1.26.2
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/cosi-project/runtime v1.14.1


### PR DESCRIPTION
## Summary

`govulncheck` flags two Go standard-library vulnerabilities present in go1.26.3, fixed in **go1.26.4**:

- **GO-2026-5039** (net/textproto: unescaped inputs in errors) — reached via `internal/tools/lifecycle.go:646`
- **GO-2026-5037** (crypto/x509: inefficient candidate hostname parsing) — reached via `internal/tools/files.go:211`

Bumps **only** the `toolchain` directive (`go1.26.3` → `go1.26.4`); the `go 1.26.2` language directive is unchanged. Stdlib CVEs cannot be fixed by pinning third-party modules, and raising the language directive would needlessly raise the consumer minimum. CI resolves Go via `go-version-file: go.mod`, so the fix applies uniformly.

## Verification (GOTOOLCHAIN=go1.26.4)

- `make check`: exit 0
- `go mod verify`: all modules verified
- `govulncheck ./...`: **0 vulnerabilities** (was 2)

Unblocks #202 (the verify job there fails on these same stdlib CVEs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)